### PR TITLE
Add deduplication attribute to metrics

### DIFF
--- a/internal/ct/otel.go
+++ b/internal/ct/otel.go
@@ -31,6 +31,7 @@ var (
 	codeKey      = attribute.Key("http.response.status_code")
 	operationKey = attribute.Key("tesseract.operation")
 	originKey    = attribute.Key("tesseract.origin")
+	dedupedKey   = attribute.Key("tesseract.dedup")
 )
 
 func mustCreate[T any](t T, err error) T {


### PR DESCRIPTION
This PR allows each handler to return additional attributes to be set on the monitoring metrics, and uses this to set the duplicate attribute. It's not the cleanest way of doing this, and I'm hoping to refactor the whole handler setup at some point, but it's okay for now.

The same applies for how handlers detect whether or not an entry has been deduped with timestamp, I think we can do better and cleaner, but let's get back to this later.