### PR TITLE
Enable publication awaiter option in AWS and GCP

### DIFF
--- a/cmd/aws/main.go
+++ b/cmd/aws/main.go
@@ -73,6 +73,7 @@ var (
 	batchMaxSize               = flag.Uint("batch_max_size", tessera.DefaultBatchMaxSize, "Maximum number of entries to process in a single Tessera sequencing batch.")
 	batchMaxAge                = flag.Duration("batch_max_age", tessera.DefaultBatchMaxAge, "Maximum age of entries in a single Tessera sequencing batch.")
 	pushbackMaxOutstanding     = flag.Uint("pushback_max_outstanding", tessera.DefaultPushbackMaxOutstanding, "Maximum number of number of in-flight add requests - i.e. the number of entries with sequence numbers assigned, but which are not yet integrated into the log.")
+	enablePublicationAwaiter   = flag.Bool("enable_publication_awaiter", false, "If true then the certificate is integrated into log before returning the response.")
 )
 
 // nolint:staticcheck
@@ -179,7 +180,7 @@ func newAWSStorage(ctx context.Context, signer note.Signer) (*storage.CTStorage,
 		return nil, fmt.Errorf("failed to initialize AWS issuer storage: %v", err)
 	}
 
-	return storage.NewCTStorage(ctx, appender, issuerStorage, reader)
+	return storage.NewCTStorage(ctx, appender, issuerStorage, reader, *enablePublicationAwaiter)
 }
 
 type timestampFlag struct {

--- a/cmd/gcp/main.go
+++ b/cmd/gcp/main.go
@@ -67,6 +67,7 @@ var (
 	batchMaxSize               = flag.Uint("batch_max_size", tessera.DefaultBatchMaxSize, "Maximum number of entries to process in a single sequencing batch.")
 	batchMaxAge                = flag.Duration("batch_max_age", tessera.DefaultBatchMaxAge, "Maximum age of entries in a single sequencing batch.")
 	pushbackMaxOutstanding     = flag.Uint("pushback_max_outstanding", tessera.DefaultPushbackMaxOutstanding, "Maximum number of number of in-flight add requests - i.e. the number of entries with sequence numbers assigned, but which are not yet integrated into the log.")
+	enablePublicationAwaiter   = flag.Bool("enable_publication_awaiter", false, "If true then the certificate is integrated into log before returning the response.")
 	traceFraction              = flag.Float64("trace_fraction", 0, "Fraction of open-telemetry span traces to sample")
 	otelProjectID              = flag.String("otel_project_id", "", "GCP project ID for OpenTelemetry exporter. This is only required for local runs.")
 )
@@ -192,7 +193,7 @@ func newGCPStorage(ctx context.Context, signer note.Signer) (*storage.CTStorage,
 		return nil, fmt.Errorf("failed to initialize GCP issuer storage: %v", err)
 	}
 
-	return storage.NewCTStorage(ctx, appender, issuerStorage, reader)
+	return storage.NewCTStorage(ctx, appender, issuerStorage, reader, *enablePublicationAwaiter)
 }
 
 type timestampFlag struct {

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -132,6 +132,36 @@ MiB Swap:      0.0 total,      0.0 free,      0.0 used.   5921.5 avail Mem
 
 </details>
 
+##### Publication Awaiter Enabled
+
+The following flags are used:
+
+- `--enable_publication_awaiter`
+- `--checkpoint_interval=1500ms`
+
+When the publication awaiter is enabled, the write QPS drops to around 500. The bottleneck comes from the checkpoint publishing wait time. The VM CPU utilization is around 75%. The Cloud Spanner CPU utilization is around 35%.
+
+```
+┌───────────────────────────────────────────────────────────────────────┐
+│Read (0 workers): Current max: 0/s. Oversupply in last second: 0       │
+│Write (4096 workers): Current max: 526/s. Oversupply in last second: 0 │
+│TreeSize: 23350671 (Δ 499qps over 30s)                                 │
+│Time-in-queue: 105ms/1245ms/5556ms (min/avg/max)                       │
+│Observed-time-to-integrate: 168ms/1769ms/7150ms (min/avg/max)          │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+```
+top - 00:06:07 up  1:06,  2 users,  load average: 1.81, 1.83, 1.65
+Tasks:  97 total,   2 running,  95 sleeping,   0 stopped,   0 zombie
+%Cpu(s): 70.8 us,  3.8 sy,  0.0 ni, 21.4 id,  0.0 wa,  0.0 hi,  3.8 si,  0.2 st 
+MiB Mem :   7950.7 total,   4186.9 free,   2370.5 used,   1657.7 buff/cache     
+MiB Swap:      0.0 total,      0.0 free,      0.0 used.   5580.2 avail Mem 
+
+    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND                                                                                                               
+   4886 user      20   0 5289880   1.2g  28172 R 154.8  15.2  46:12.52 gcp                                                                                                                   
+```
+
 ### AWS
 
 The indicative figures below were measured using the [CT hammer tool](/internal/hammer/) as of [commit `fe7687c`](https://github.com/transparency-dev/tesseract/commit/fe7687c9ed35d11f42a211ee35544ff6c5610ee6).

--- a/internal/ct/handlers_test.go
+++ b/internal/ct/handlers_test.go
@@ -185,7 +185,7 @@ func newPOSIXStorageFunc(t *testing.T, root string) storage.CreateStorage {
 			klog.Fatalf("failed to initialize InMemory issuer storage: %v", err)
 		}
 
-		s, err := storage.NewCTStorage(t.Context(), appender, issuerStorage, reader)
+		s, err := storage.NewCTStorage(t.Context(), appender, issuerStorage, reader, false)
 		if err != nil {
 			klog.Fatalf("Failed to initialize CTStorage: %v", err)
 		}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -57,20 +57,22 @@ type IssuerStorage interface {
 
 // CTStorage implements ct.Storage and tessera.LogReader.
 type CTStorage struct {
-	storeData    func(context.Context, *ctonly.Entry) tessera.IndexFuture
-	storeIssuers func(context.Context, []KV) error
-	reader       tessera.LogReader
-	awaiter      *tessera.PublicationAwaiter
+	storeData     func(context.Context, *ctonly.Entry) tessera.IndexFuture
+	storeIssuers  func(context.Context, []KV) error
+	reader        tessera.LogReader
+	awaiter       *tessera.PublicationAwaiter
+	enableAwaiter bool
 }
 
 // NewCTStorage instantiates a CTStorage object.
-func NewCTStorage(ctx context.Context, logStorage *tessera.Appender, issuerStorage IssuerStorage, reader tessera.LogReader) (*CTStorage, error) {
+func NewCTStorage(ctx context.Context, logStorage *tessera.Appender, issuerStorage IssuerStorage, reader tessera.LogReader, enableAwaiter bool) (*CTStorage, error) {
 	awaiter := tessera.NewPublicationAwaiter(ctx, reader.ReadCheckpoint, 200*time.Millisecond)
 	ctStorage := &CTStorage{
-		storeData:    tessera.NewCertificateTransparencyAppender(logStorage),
-		storeIssuers: cachedStoreIssuers(issuerStorage),
-		reader:       reader,
-		awaiter:      awaiter,
+		storeData:     tessera.NewCertificateTransparencyAppender(logStorage),
+		storeIssuers:  cachedStoreIssuers(issuerStorage),
+		reader:        reader,
+		awaiter:       awaiter,
+		enableAwaiter: enableAwaiter,
 	}
 	return ctStorage, nil
 }
@@ -81,13 +83,13 @@ func (cts *CTStorage) ReadCheckpoint(ctx context.Context) ([]byte, error) {
 
 // TODO(phbnf): cache timestamps (or more) to avoid reparsing the entire leaf bundle
 func (cts *CTStorage) dedupFuture(ctx context.Context, f tessera.IndexFuture) (index, timestamp uint64, err error) {
-	ctx, span := tracer.Start(ctx, "tesseract.storage.dedupFuture")
-	defer span.End()
-
 	idx, cpRaw, err := cts.awaiter.Await(ctx, f)
 	if err != nil {
-		return 0, 0, fmt.Errorf("error waiting for Tessera future and its integration: %w", err)
+		return 0, 0, fmt.Errorf("error waiting for Tessera index future and its integration: %w", err)
 	}
+
+	ctx, span := tracer.Start(ctx, "tesseract.storage.dedup")
+	defer span.End()
 
 	// A https://c2sp.org/static-ct-api logsize is on the second line
 	l := bytes.SplitN(cpRaw, []byte("\n"), 3)
@@ -131,15 +133,28 @@ func (cts *CTStorage) Add(ctx context.Context, entry *ctonly.Entry) (uint64, uin
 	defer span.End()
 
 	future := cts.storeData(ctx, entry)
-	idx, err := future()
-	if err != nil {
-		return 0, 0, fmt.Errorf("error waiting for Tessera future: %w", err)
-	}
-	if idx.IsDup {
-		return cts.dedupFuture(ctx, future)
-	}
-	return idx.Index, entry.Timestamp, nil
 
+	if cts.enableAwaiter {
+		idx, _, err := cts.awaiter.Await(ctx, future)
+		if err != nil {
+			return 0, 0, fmt.Errorf("error waiting for Tessera index future and its integration: %w", err)
+		}
+		if idx.IsDup {
+			return cts.dedupFuture(ctx, future)
+		}
+
+		return idx.Index, entry.Timestamp, nil
+	} else {
+		idx, err := future()
+		if err != nil {
+			return 0, 0, fmt.Errorf("error waiting for Tessera index future: %w", err)
+		}
+		if idx.IsDup {
+			return cts.dedupFuture(ctx, future)
+		}
+
+		return idx.Index, entry.Timestamp, nil
+	}
 }
 
 // AddIssuerChain stores every chain certificate under its sha256.

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -83,13 +83,13 @@ func (cts *CTStorage) ReadCheckpoint(ctx context.Context) ([]byte, error) {
 
 // TODO(phbnf): cache timestamps (or more) to avoid reparsing the entire leaf bundle
 func (cts *CTStorage) dedupFuture(ctx context.Context, f tessera.IndexFuture) (index, timestamp uint64, err error) {
+	ctx, span := tracer.Start(ctx, "tesseract.storage.dedupFuture")
+	defer span.End()
+
 	idx, cpRaw, err := cts.awaiter.Await(ctx, f)
 	if err != nil {
 		return 0, 0, fmt.Errorf("error waiting for Tessera index future and its integration: %w", err)
 	}
-
-	ctx, span := tracer.Start(ctx, "tesseract.storage.dedup")
-	defer span.End()
 
 	// A https://c2sp.org/static-ct-api logsize is on the second line
 	l := bytes.SplitN(cpRaw, []byte("\n"), 3)


### PR DESCRIPTION
Towards https://github.com/transparency-dev/tesseract/issues/331.

**Load test result on e2-standard-2 (2 vCPUs, 8 GB Memory)**
The tree growth rate is 500/s. 

```
┌───────────────────────────────────────────────────────────────────────┐
│Read (0 workers): Current max: 0/s. Oversupply in last second: 0       │
│Write (4096 workers): Current max: 526/s. Oversupply in last second: 0 │
│TreeSize: 23350671 (Δ 499qps over 30s)                                 │
│Time-in-queue: 105ms/1245ms/5556ms (min/avg/max)                       │
│Observed-time-to-integrate: 168ms/1769ms/7150ms (min/avg/max)          │
└───────────────────────────────────────────────────────────────────────┘
```

---

There are context canceled errors when the CT Hammer write rate is 1/s. This is caused by the checkpoint issuance frequency which is 10s by default.

```
I0528 14:55:58.838138   23617 gcp.go:563] New tree: 18473254, 53c93f3cc95a928f83749b412f3b188d69e9dbf601bae2778f1c3b5d5da33050
I0528 14:55:59.949590   23617 gcp.go:563] New tree: 18473255, 84ca31ceae938b22cfffb4677c3e1046cca30bbcc5cb8f6f6e722cdea77cba83
I0528 14:56:00.803160   23617 gcp.go:563] New tree: 18473256, b073541d2f923f02331c0b3f5eaf89c13d303e851739f95720f348f0a0d1f0e0
I0528 14:56:01.796035   23617 gcp.go:563] New tree: 18473257, 7f41946baa8b873b15a74ad78f99a1aac7715bbda71003dc6cff2f4813fdcd68
I0528 14:56:02.815314   23617 gcp.go:563] New tree: 18473258, f10dee3d19ce4ea1557d6eb8ce39dec458240ecc32148f2275e05517f4b4e068
I0528 14:56:03.967493   23617 gcp.go:563] New tree: 18473259, f9e436972e1cb8026a12c6c4332c7b688fbd3bea2f054da4a2afbec743921aec
I0528 14:56:04.791391   23617 gcp.go:563] New tree: 18473260, 792adba2ea69955f85893afd14f14fe3da58ba26c425c67325b1e33d1882c854
I0528 14:56:05.896786   23617 gcp.go:563] New tree: 18473261, a598bc78766c14734b4f1bf766ea5ce04184d14259efee8709aedb189d6675ff
W0528 14:56:07.059970   23617 handlers.go:164] test-static-ct: AddChain handler error: couldn't store the leaf: error waiting for Tessera index future and its integration: context canceled
W0528 14:56:08.058910   23617 handlers.go:164] test-static-ct: AddChain handler error: couldn't store the leaf: error waiting for Tessera index future and its integration: context canceled
W0528 14:56:09.058870   23617 handlers.go:164] test-static-ct: AddChain handler error: couldn't store the leaf: error waiting for Tessera index future and its integration: context canceled
W0528 14:56:10.060064   23617 handlers.go:164] test-static-ct: AddChain handler error: couldn't store the leaf: error waiting for Tessera index future and its integration: context canceled
I0528 14:56:14.795691   23617 gcp.go:563] New tree: 18473262, 8d602e8fbbcec56ec0897124cf5a4dc80a6009a865c6e615cd0c3741db83c688
I0528 14:56:15.924434   23617 gcp.go:563] New tree: 18473263, bc1ae0a4a7ec0ed88998f7001192f5ae33b144c3d5fd539a6dc3251924fcc8e5
I0528 14:56:16.799998   23617 gcp.go:563] New tree: 18473264, ebbfeade7b07671b51dc872f0214c43b850562ebc35f03e02789b919497101f0
I0528 14:56:17.860101   23617 gcp.go:563] New tree: 18473265, da1393fbe6d28e1a7bb60d8f700a1ba31a39344ec36ca98ae3c122980343e360
I0528 14:56:18.964462   23617 gcp.go:563] New tree: 18473266, 77699bddab2a5cfdc1bdfd8175c1506eabea71950a6e1cca804b4e0cfa13494f
W0528 14:56:19.058922   23617 handlers.go:164] test-static-ct: AddChain handler error: couldn't store the leaf: error waiting for Tessera index future and its integration: context canceled
I0528 14:56:19.794401   23617 gcp.go:563] New tree: 18473267, 9dd8c54ae4a1ee6e2934be52841f75a4b54b115ac4b6106ade75326f7ae51c79
W0528 14:56:20.058544   23617 handlers.go:164] test-static-ct: AddChain handler error: couldn't store the leaf: error waiting for Tessera index future and its integration: context canceled
I0528 14:56:20.798873   23617 gcp.go:563] New tree: 18473268, 4c969fa61ed982431899e7ab962edfc3ead3813cd9e8ededacc237ece6cae775
W0528 14:56:21.060237   23617 handlers.go:164] test-static-ct: AddChain handler error: couldn't store the leaf: error waiting for Tessera index future and its integration: context canceled
I0528 14:56:21.804384   23617 gcp.go:563] New tree: 18473269, a0efa8f0385d5dd87b74bbc1343360b52ed1103da201d050267a2e334e7fdadc
```

When the checkpoint interval is updated to 1.5s, the errors are gone.