### PR TITLE
Fix missing `-` from `Retry-After` header in hammer

### DIFF
--- a/internal/hammer/loadtest/client.go
+++ b/internal/hammer/loadtest/client.go
@@ -184,9 +184,9 @@ func (w httpLeafWriter) Write(ctx context.Context, newLeaf []byte) (uint64, uint
 			return 0, 0, fmt.Errorf("write leaf was redirected to %s", resp.Request.URL)
 		}
 		// Continue below
-	case http.StatusServiceUnavailable, http.StatusBadGateway, http.StatusGatewayTimeout:
+	case http.StatusServiceUnavailable, http.StatusBadGateway, http.StatusGatewayTimeout, http.StatusTooManyRequests:
 		// These status codes may indicate a delay before retrying, so handle that here:
-		time.Sleep(retryDelay(resp.Header.Get("RetryAfter"), time.Second))
+		time.Sleep(retryDelay(resp.Header.Get("Retry-After"), time.Second))
 
 		return 0, 0, fmt.Errorf("log not available. Status code: %d. Body: %q %w", resp.StatusCode, body, ErrRetry)
 	default:


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Retry-After