### PR TITLE
Set trace_fraction and harmonize defaults

### DIFF
--- a/deployment/live/gcp/static-ct-staging/logs/arche2025h1/terragrunt.hcl
+++ b/deployment/live/gcp/static-ct-staging/logs/arche2025h1/terragrunt.hcl
@@ -11,6 +11,7 @@ locals {
   not_after_limit     = "2025-07-01T00:00:00Z"
   server_docker_image = "${include.root.locals.location}-docker.pkg.dev/${include.root.locals.project_id}/docker-${local.env}/tesseract-gcp:${include.root.locals.docker_container_tag}"
   spanner_pu          = 500
+  trace_fraction      = 0.1
 }
 
 include "root" {

--- a/deployment/live/gcp/static-ct-staging/logs/arche2025h2/terragrunt.hcl
+++ b/deployment/live/gcp/static-ct-staging/logs/arche2025h2/terragrunt.hcl
@@ -11,6 +11,7 @@ locals {
   not_after_limit     = "2026-01-01T00:00:00Z"
   server_docker_image = "${include.root.locals.location}-docker.pkg.dev/${include.root.locals.project_id}/docker-${local.env}/tesseract-gcp:${include.root.locals.docker_container_tag}"
   spanner_pu          = 500
+  trace_fraction      = 0.1
 }
 
 include "root" {

--- a/deployment/modules/gcp/cloudrun/main.tf
+++ b/deployment/modules/gcp/cloudrun/main.tf
@@ -52,6 +52,7 @@ resource "google_cloud_run_v2_service" "default" {
       	"--inmemory_antispam_cache_size=25000000", # About 1GB of memory.
         "--not_after_start=${var.not_after_start}",
         "--not_after_limit=${var.not_after_limit}",
+        "--trace_fraction=${var.trace_fraction}"
       ]
       ports {
         container_port = 6962

--- a/deployment/modules/gcp/cloudrun/variables.tf
+++ b/deployment/modules/gcp/cloudrun/variables.tf
@@ -60,12 +60,15 @@ variable "signer_private_key_secret_name" {
 
 variable "not_after_start" {
   description = "Start of the range of acceptable NotAfter values, inclusive. Leaving this empty implies no lower bound to the range. RFC3339 UTC format, e.g: 2024-01-02T15:04:05Z."
-  default     = ""
   type        = string
 }
 
 variable "not_after_limit" {
   description = "Cut off point of notAfter dates - only notAfter dates strictly *before* notAfterLimit will be accepted. Leaving this empty means no upper bound on the accepted range. RFC3339 UTC format, e.g: 2024-01-02T15:04:05Z."
-  default     = ""
   type        = string
+}
+
+variable "trace_fraction" {
+  description = "Fraction of open-telemetry span traces to sample."
+  type        = number
 }

--- a/deployment/modules/gcp/tesseract/cloudrun/main.tf
+++ b/deployment/modules/gcp/tesseract/cloudrun/main.tf
@@ -35,6 +35,7 @@ module "cloudrun" {
   antispam_spanner_db            = module.storage.antispam_spanner_db.name
   signer_public_key_secret_name  = module.secretmanager.ecdsa_p256_public_key_id
   signer_private_key_secret_name = module.secretmanager.ecdsa_p256_private_key_id
+  trace_fraction                 = var.trace_fraction
 
   depends_on = [
     module.secretmanager,

--- a/deployment/modules/gcp/tesseract/cloudrun/variables.tf
+++ b/deployment/modules/gcp/tesseract/cloudrun/variables.tf
@@ -56,3 +56,9 @@ variable "ephemeral" {
   default     = false
   type        = bool
 }
+
+variable "trace_fraction" {
+  description = "Fraction of open-telemetry span traces to sample."
+  default     = 0
+  type        = number
+}


### PR DESCRIPTION
Set trace_fraction to 0.1 for Arche instances, and only set default values in the tesseract service invocation, not at the CloudRun (soon to be VM) level to avoid having to keep two default values in sync.

Towards #104 