### PR TITLE
Add VPC to cloudrun service

### DIFF
--- a/deployment/modules/gcp/cloudrun/main.tf
+++ b/deployment/modules/gcp/cloudrun/main.tf
@@ -77,6 +77,16 @@ resource "google_cloud_run_v2_service" "default" {
         }
       }
     }
+    // Attach a VPC for better throughput:
+    // https://cloud.google.com/run/docs/configuring/networking-best-practices#direct-vpc-throughput
+    vpc_access {
+      network_interfaces {
+        network    = "default"
+        subnetwork = "default"
+        tags       = ["tesseract",]
+      }
+      egress = "ALL_TRAFFIC"
+    }
   }
 
   deletion_protection = false


### PR DESCRIPTION
We're not going to use CloudRun for our logs, but I'm sending all the PRs we had in the works in case we want to use it later, and to make the conformance binary setup better.