### PR TITLE
Parallel and indempotent writes for issuers

### DIFF
--- a/storage/aws/issuers.go
+++ b/storage/aws/issuers.go
@@ -19,13 +19,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"path"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/smithy-go"
+	"github.com/google/go-cmp/cmp"
 	"github.com/transparency-dev/tesseract/storage"
+	"golang.org/x/sync/errgroup"
 	"k8s.io/klog/v2"
 )
 
@@ -62,31 +65,66 @@ func (s *IssuersStorage) keyToObjName(key []byte) string {
 }
 
 // AddIssuers stores Issuers values under their Key if there isn't an object under Key already.
+// Wrap with a local cache to avoid unecessary read and write operations as issuers are reused
+// accross chains.
 func (s *IssuersStorage) AddIssuersIfNotExist(ctx context.Context, kv []storage.KV) error {
-	// We first try and see if this issuer cert has already been stored since reads
-	// are cheaper than writes.
+	errG := errgroup.Group{}
 	for _, kv := range kv {
-		objName := s.keyToObjName(kv.K)
-		put := &s3.PutObjectInput{
-			Bucket:      aws.String(s.bucket),
-			Key:         aws.String(objName),
-			Body:        bytes.NewReader(kv.V),
-			ContentType: aws.String(s.contentType),
-			IfNoneMatch: aws.String("*"),
-		}
-
-		// If we run into a precondition failure error, check that the object
-		// which exists contains the same content that we want to write.
-		// If so, we can consider this write to be idempotently successful.
-		if _, err := s.s3Client.PutObject(ctx, put); err != nil {
-			var apiErr smithy.APIError
-			if errors.As(err, &apiErr); apiErr.ErrorCode() == "PreconditionFailed" {
-				klog.V(2).Infof("AddIssuersIfNotExist: object %q already exists in bucket %q, continuing", objName, s.bucket)
-				return nil
+		errG.Go(func() error {
+			objName := s.keyToObjName(kv.K)
+			put := &s3.PutObjectInput{
+				Bucket:      aws.String(s.bucket),
+				Key:         aws.String(objName),
+				Body:        bytes.NewReader(kv.V),
+				ContentType: aws.String(s.contentType),
+				IfNoneMatch: aws.String("*"),
 			}
-			return fmt.Errorf("failed to write object %q to bucket %q: %w", objName, s.bucket, err)
-		}
-		klog.V(2).Infof("AddIssuersIfNotExist: added %q in bucket %q", objName, s.bucket)
+
+			// If we run into a precondition failure error, check that the object
+			// which exists contains the same content that we want to write.
+			// If so, we can consider this write to be idempotently successful.
+			if _, err := s.s3Client.PutObject(ctx, put); err != nil {
+				var apiErr smithy.APIError
+				if errors.As(err, &apiErr); apiErr.ErrorCode() == "PreconditionFailed" {
+					existing, err := s.getIssuer(ctx, objName)
+					if err != nil {
+						return fmt.Errorf("failed to fetch existing content for %q: %v", objName, err)
+					}
+					if !bytes.Equal(existing, kv.V) {
+						klog.Errorf("Resource %q non-idempotent write:\n%s", objName, cmp.Diff(existing, kv.V))
+						return fmt.Errorf("precondition failed: resource content for %q differs from data to-be-written", objName)
+					}
+
+					klog.V(2).Infof("AddIssuersIfNotExist: object %q already exists in bucket %q, continuing", objName, s.bucket)
+					return nil
+				}
+				return fmt.Errorf("failed to write object %q to bucket %q: %w", objName, s.bucket, err)
+			}
+			klog.V(2).Infof("AddIssuersIfNotExist: added %q in bucket %q", objName, s.bucket)
+			return nil
+		})
 	}
+
+	if err := errG.Wait(); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// getIssuer returns the issuer at the specified key, or an error.
+func (s *IssuersStorage) getIssuer(ctx context.Context, obj string) ([]byte, error) {
+	r, err := s.s3Client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(obj),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("getIssuer: failed to create reader for issuer %q in bucket %q: %w", obj, s.bucket, err)
+	}
+
+	d, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, fmt.Errorf("getIssuer: failed to read %q: %v", obj, err)
+	}
+	return d, r.Body.Close()
 }

--- a/storage/gcp/issuers.go
+++ b/storage/gcp/issuers.go
@@ -15,13 +15,17 @@
 package gcp
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"path"
 
 	gcs "cloud.google.com/go/storage"
+	"github.com/google/go-cmp/cmp"
 	"github.com/transparency-dev/tesseract/storage"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/googleapi"
 	"k8s.io/klog/v2"
 )
@@ -57,35 +61,62 @@ func (s *IssuersStorage) keyToObjName(key []byte) string {
 }
 
 // AddIssuers stores Issuers values under their Key if there isn't an object under Key already.
+// Wrap with a local cache to avoid unecessary read and write operations as issuers are reused
+// accross chains.
 func (s *IssuersStorage) AddIssuersIfNotExist(ctx context.Context, kv []storage.KV) error {
-	// We first try and see if this issuer cert has already been stored since reads
-	// are cheaper than writes.
-	// TODO(phboneff): add parallel operations
+	errG := errgroup.Group{}
 	for _, kv := range kv {
-		objName := s.keyToObjName(kv.K)
-		obj := s.bucket.Object(objName)
+		errG.Go(func() error {
+			objName := s.keyToObjName(kv.K)
+			obj := s.bucket.Object(objName)
 
-		w := obj.If(gcs.Conditions{DoesNotExist: true}).NewWriter(ctx)
-		w.ContentType = s.contentType
+			w := obj.If(gcs.Conditions{DoesNotExist: true}).NewWriter(ctx)
+			w.ContentType = s.contentType
 
-		if _, err := w.Write(kv.V); err != nil {
-			return fmt.Errorf("failed to write object %q to bucket %q: %w", objName, s.bucket.BucketName(), err)
-		}
-
-		if err := w.Close(); err != nil {
-			if ee, ok := err.(*googleapi.Error); ok && ee.Code == http.StatusPreconditionFailed {
-				for _, e := range ee.Errors {
-					if e.Reason == "conditionNotMet" {
-						klog.V(2).Infof("AddIssuersIfNotExist: object %q already exists in bucket %q, continuing", objName, s.bucket.BucketName())
-						return nil
-					}
-				}
+			if _, err := w.Write(kv.V); err != nil {
+				return fmt.Errorf("failed to write object %q to bucket %q: %w", objName, s.bucket.BucketName(), err)
 			}
 
-			return fmt.Errorf("failed to close write on %q: %v", objName, err)
-		}
-
-		klog.V(2).Infof("AddIssuersIfNotExist: added %q in bucket %q", objName, s.bucket.BucketName())
+			if err := w.Close(); err != nil {
+				// If we run into a precondition failure error, check that the object
+				// which exists contains the same content that we want to write.
+				// If so, we can consider this write to be idempotently successful.
+				if ee, ok := err.(*googleapi.Error); ok && ee.Code == http.StatusPreconditionFailed {
+					existing, existingGen, err := s.getIssuer(ctx, objName)
+					if err != nil {
+						return fmt.Errorf("failed to fetch existing content for %q (@%d): %v", objName, existingGen, err)
+					}
+					if !bytes.Equal(existing, kv.V) {
+						klog.Errorf("Resource %q non-idempotent write:\n%s", objName, cmp.Diff(existing, kv.V))
+						return fmt.Errorf("precondition failed: resource content for %q differs from data to-be-written", objName)
+					}
+					klog.V(2).Infof("AddIssuersIfNotExist: object %q already exists in bucket %q, continuing", objName, s.bucket.BucketName())
+					return nil
+				}
+				return fmt.Errorf("failed to close write on %q: %v", objName, err)
+			}
+			klog.V(2).Infof("AddIssuersIfNotExist: added %q in bucket %q", objName, s.bucket.BucketName())
+			return nil
+		})
 	}
+
+	if err := errG.Wait(); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// getIssuer returns the data and generation of the specified issuer, or an error.
+func (s *IssuersStorage) getIssuer(ctx context.Context, key string) ([]byte, int64, error) {
+	r, err := s.bucket.Object(key).NewReader(ctx)
+	if err != nil {
+		return nil, -1, fmt.Errorf("getIssuer: failed to create reader for issuer %q in bucket %q: %w", key, s.bucket.BucketName(), err)
+	}
+
+	d, err := io.ReadAll(r)
+	if err != nil {
+		return nil, -1, fmt.Errorf("failed to read isuer %q: %v", key, err)
+	}
+	return d, r.Attrs.Generation, r.Close()
 }


### PR DESCRIPTION
Much inspired by Tessera's [gcp setObject](https://github.com/transparency-dev/tessera/blob/3fcd51d6bf6389f1c89b4f43858e09b194649d3d/storage/gcp/gcp.go#L1126), and [aws setObjectIfNoneMatch](https://github.com/transparency-dev/tessera/blob/3fcd51d6bf6389f1c89b4f43858e09b194649d3d/storage/aws/aws.go#L1362)