### PR TITLE
Remove Cloud Rrun VPC

### DIFF
--- a/deployment/modules/gcp/cloudrun/README.md.md
+++ b/deployment/modules/gcp/cloudrun/README.md.md
@@ -1,0 +1,5 @@
+# Cloud Run
+
+## Tips
+
+You may want to attach your service to a VPC to allow for [better throughput](https://cloud.google.com/run/docs/configuring/networking-best-practices#direct-vpc-throughput).

--- a/deployment/modules/gcp/cloudrun/main.tf
+++ b/deployment/modules/gcp/cloudrun/main.tf
@@ -77,16 +77,6 @@ resource "google_cloud_run_v2_service" "default" {
         }
       }
     }
-    // Attach a VPC for better throughput:
-    // https://cloud.google.com/run/docs/configuring/networking-best-practices#direct-vpc-throughput
-    vpc_access {
-      network_interfaces {
-        network    = "default"
-        subnetwork = "default"
-        tags       = ["tesseract",]
-      }
-      egress = "ALL_TRAFFIC"
-    }
   }
 
   deletion_protection = false


### PR DESCRIPTION
It break the CI environment, and we don't need this in staging since we don't use Cloud Run anymore.