### PR TITLE
Fix issuer path

### DIFF
--- a/cmd/aws/main.go
+++ b/cmd/aws/main.go
@@ -190,7 +190,7 @@ func newAWSStorage(ctx context.Context, signer note.Signer) (*storage.CTStorage,
 		return nil, fmt.Errorf("failed to initialize AWS Tessera storage: %v", err)
 	}
 
-	issuerStorage, err := aws.NewIssuerStorage(ctx, *bucket, "fingerprints/", "application/pkix-cert")
+	issuerStorage, err := aws.NewIssuerStorage(ctx, *bucket)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize AWS issuer storage: %v", err)
 	}

--- a/cmd/gcp/main.go
+++ b/cmd/gcp/main.go
@@ -203,7 +203,7 @@ func newGCPStorage(ctx context.Context, signer note.Signer) (*storage.CTStorage,
 		return nil, fmt.Errorf("failed to initialize GCP Tessera appender: %v", err)
 	}
 
-	issuerStorage, err := gcp.NewIssuerStorage(ctx, *bucket, "fingerprints/", "application/pkix-cert")
+	issuerStorage, err := gcp.NewIssuerStorage(ctx, *bucket)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize GCP issuer storage: %v", err)
 	}

--- a/internal/ct/handlers_test.go
+++ b/internal/ct/handlers_test.go
@@ -72,9 +72,8 @@ var (
 		TimeSource:         timeSource,
 	}
 
-	// POSIX subdirectories
+	// POSIX subdirectory
 	logDir = "log"
-	issDir = "issuers"
 )
 
 type fixedTimeSource struct {
@@ -180,7 +179,7 @@ func newPOSIXStorageFunc(t *testing.T, root string) storage.CreateStorage {
 			klog.Fatalf("Failed to initialize POSIX Tessera appender: %v", err)
 		}
 
-		issuerStorage, err := posix.NewIssuerStorage(path.Join(root, issDir))
+		issuerStorage, err := posix.NewIssuerStorage(path.Join(root, logDir))
 		if err != nil {
 			klog.Fatalf("failed to initialize InMemory issuer storage: %v", err)
 		}
@@ -589,7 +588,7 @@ func TestAddChain(t *testing.T) {
 				// Check that the issuers have been populated correctly.
 				for _, wantIss := range wantIssChain[1:] {
 					key := sha256.Sum256(wantIss.Raw)
-					issPath := path.Join(dir, issDir, hex.EncodeToString(key[:]))
+					issPath := path.Join(dir, logDir, staticct.IssuersPrefix, hex.EncodeToString(key[:]))
 					gotIss, err := os.ReadFile(issPath)
 					if err != nil {
 						t.Errorf("Failed to read issuer at %q: %v", issPath, err)
@@ -736,7 +735,7 @@ func TestAddPreChain(t *testing.T) {
 				// Check that the issuers have been populated correctly.
 				for _, wantIss := range wantIssChain[1:] {
 					key := sha256.Sum256(wantIss.Raw)
-					issPath := path.Join(dir, issDir, hex.EncodeToString(key[:]))
+					issPath := path.Join(dir, logDir, staticct.IssuersPrefix, hex.EncodeToString(key[:]))
 					gotIss, err := os.ReadFile(issPath)
 					if err != nil {
 						t.Errorf("Failed to read issuer at %q: %v", issPath, err)

--- a/internal/testonly/storage/posix/issuers.go
+++ b/internal/testonly/storage/posix/issuers.go
@@ -23,8 +23,10 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
+	"github.com/transparency-dev/tesseract/internal/types/staticct"
 	"github.com/transparency-dev/tesseract/storage"
 	"k8s.io/klog/v2"
 )
@@ -37,10 +39,11 @@ type IssuersStorage string
 // It creates the underying directory if it does not exist already.
 func NewIssuerStorage(path string) (IssuersStorage, error) {
 	// Does nothing if the dictory already exists.
-	if err := os.MkdirAll(path, 0755); err != nil {
+	p := filepath.Join(path, staticct.IssuersPrefix)
+	if err := os.MkdirAll(p, 0755); err != nil {
 		return "", fmt.Errorf("failed to create path %q: %v", path, err)
 	}
-	return IssuersStorage(path), nil
+	return IssuersStorage(p), nil
 }
 
 // keyToObjName converts bytes to filesystem path.

--- a/internal/types/staticct/staticct.go
+++ b/internal/types/staticct/staticct.go
@@ -24,6 +24,11 @@ import (
 	"golang.org/x/crypto/cryptobyte"
 )
 
+const (
+	IssuersPrefix      = "issuer/"
+	IssuersContentType = "application/pkix-cert"
+)
+
 ///////////////////////////////////////////////////////////////////////////////
 // The following structures represent those outlined in Static CT API.
 ///////////////////////////////////////////////////////////////////////////////

--- a/storage/aws/issuers.go
+++ b/storage/aws/issuers.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/smithy-go"
+	"github.com/transparency-dev/tesseract/internal/types/staticct"
 	"github.com/transparency-dev/tesseract/storage"
 	"k8s.io/klog/v2"
 )
@@ -40,7 +41,7 @@ type IssuersStorage struct {
 // NewIssuerStorage creates a new IssuerStorage.
 //
 // The specified bucket must exist or an error will be returned.
-func NewIssuerStorage(ctx context.Context, bucket string, prefix string, contentType string) (*IssuersStorage, error) {
+func NewIssuerStorage(ctx context.Context, bucket string) (*IssuersStorage, error) {
 	sdkConfig, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load default AWS configuration: %v", err)
@@ -49,8 +50,8 @@ func NewIssuerStorage(ctx context.Context, bucket string, prefix string, content
 	r := &IssuersStorage{
 		s3Client:    s3.NewFromConfig(sdkConfig),
 		bucket:      bucket,
-		prefix:      prefix,
-		contentType: contentType,
+		prefix:      staticct.IssuersPrefix,
+		contentType: staticct.IssuersContentType,
 	}
 
 	return r, nil

--- a/storage/gcp/issuers.go
+++ b/storage/gcp/issuers.go
@@ -21,6 +21,7 @@ import (
 	"path"
 
 	gcs "cloud.google.com/go/storage"
+	"github.com/transparency-dev/tesseract/internal/types/staticct"
 	"github.com/transparency-dev/tesseract/storage"
 	"google.golang.org/api/googleapi"
 	"k8s.io/klog/v2"
@@ -36,7 +37,7 @@ type IssuersStorage struct {
 // NewIssuerStorage creates a new GCSStorage.
 //
 // The specified bucket must exist or an error will be returned.
-func NewIssuerStorage(ctx context.Context, bucket string, prefix string, contentType string) (*IssuersStorage, error) {
+func NewIssuerStorage(ctx context.Context, bucket string) (*IssuersStorage, error) {
 	c, err := gcs.NewClient(ctx, gcs.WithJSONReads())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create GCS client: %v", err)
@@ -44,8 +45,8 @@ func NewIssuerStorage(ctx context.Context, bucket string, prefix string, content
 
 	r := &IssuersStorage{
 		bucket:      c.Bucket(bucket),
-		prefix:      prefix,
-		contentType: contentType,
+		prefix:      staticct.IssuersPrefix,
+		contentType: staticct.IssuersContentType,
 	}
 
 	return r, nil


### PR DESCRIPTION
Towards #104 #109 #110.

At the moment, issuers are stored under "fingerprints/" rather than "issuer/".

This PR fixes that, and changes function signatures in an attempt to prevent this from happening agan.