### PR TITLE
Store issuers under /issuer prefix

### DIFF
--- a/cmd/aws/main.go
+++ b/cmd/aws/main.go
@@ -190,7 +190,7 @@ func newAWSStorage(ctx context.Context, signer note.Signer) (*storage.CTStorage,
 		return nil, fmt.Errorf("failed to initialize AWS Tessera storage: %v", err)
 	}
 
-	issuerStorage, err := aws.NewIssuerStorage(ctx, *bucket, "fingerprints/", "application/pkix-cert")
+	issuerStorage, err := aws.NewIssuerStorage(ctx, *bucket, "issuer/", "application/pkix-cert")
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize AWS issuer storage: %v", err)
 	}

--- a/cmd/gcp/main.go
+++ b/cmd/gcp/main.go
@@ -203,7 +203,7 @@ func newGCPStorage(ctx context.Context, signer note.Signer) (*storage.CTStorage,
 		return nil, fmt.Errorf("failed to initialize GCP Tessera appender: %v", err)
 	}
 
-	issuerStorage, err := gcp.NewIssuerStorage(ctx, *bucket, "fingerprints/", "application/pkix-cert")
+	issuerStorage, err := gcp.NewIssuerStorage(ctx, *bucket, "issuer/", "application/pkix-cert")
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize GCP issuer storage: %v", err)
 	}


### PR DESCRIPTION
This PR corrects the location of the issuer resources in the AWS and GCP binaries.

Fixes #386 