### PR TITLE
Add experimental POSIX CT server

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ using the [Tessera](https://github.com/transparency-dev/tessera)
 library to store data, and is aimed at running production-grade CT logs.
 
 At the moment, TesseraCT can be [deployed](#️-deployment) on GCP and AWS.
+There is also an experimental binary which uses Tessera's POSIX storage backend.
 
 ## 📣 Status
 
@@ -66,6 +67,11 @@ If you're interested, [come and talk to us](#-contact)!
 At the moment, this is not officially supported. If you're interested in
 running off GCP or AWS, [read this](./docs/architecture/NONCLOUD.md) and
 [get in touch](#-contact)!
+
+There is an experimental [POSIX binary](/cmd/experimental/posix) which uses
+Tessera's POSIX backend for storing the log on local filesystems. At the moment
+this is not ready for production use, but questions and bug reports are
+very welcome!
 
 ## 🧌 History
 

--- a/cmd/experimental/posix/README.md
+++ b/cmd/experimental/posix/README.md
@@ -1,0 +1,42 @@
+# POSIX static-ct server
+
+This directory contains an experimental `static-ct` server which uses Tessera's POSIX backend for storing the log.
+It's not yet ready to be used as a production log!
+
+## Running
+
+Generate an ECDSA key like so:
+
+```bash
+$ openssl ecparam -name prime256v1 -genkey -noout -out test-ecdsa-priv.pem 
+```
+
+And then start a log with the following command:
+
+```bash
+$ go run ./cmd/experimental/posix/ \
+  --private_key=./test-ecdsa-priv.pem \
+  --origin=example.com/test-ecdsa \
+  --storage_dir=/tmp/ecdsa_log \
+  --roots_pem_file=deployment/live/gcp/static-ct-staging/logs/arche2025h1/roots.pem
+badger 2025/07/09 19:28:48 INFO: All 2 tables opened in 0s
+badger 2025/07/09 19:28:48 INFO: Discard stats nextEmptySlot: 0
+badger 2025/07/09 19:28:48 INFO: Set nextTxnTs to 79
+badger 2025/07/09 19:28:48 INFO: Deleting empty file: /tmp/ecdsa_log/.state/antispam/000003.vlog
+I0709 19:28:48.980391 1398578 main.go:95] **** CT HTTP Server Starting ****
+```
+
+The server should now be listening on port `:6962`.
+
+You can try "preloading" the log with the contents of another CT log, e.g.:
+
+```bash
+go run github.com/google/certificate-transparency-go/preload/preloader@master \
+  --target_log_uri=http://localhost:6962/example.com/test-ecdsa \
+  --source_log_uri=https://ct.googleapis.com/logs/eu1/xenon2025h2/ \
+  --num_workers=2 \
+  --start_index=130000 \
+  --parallel_fetch=2 \
+  --parallel_submit=512
+
+```

--- a/cmd/experimental/posix/main.go
+++ b/cmd/experimental/posix/main.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Google LLC. All Rights Reserved.
+// Copyright 2025 the Tessera authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ var (
 	notAfterStart timestampFlag
 	notAfterLimit timestampFlag
 
-	enablePublicationAwaiter = flag.Bool("enable_publication_awaiter", false, "If true then the certificate is integrated into log before returning the response.")
+	enablePublicationAwaiter = flag.Bool("enable_publication_awaiter", true, "If true then the certificate is integrated into log before returning the response.")
 	httpEndpoint             = flag.String("http_endpoint", "localhost:6962", "Endpoint for HTTP (host:port).")
 	httpDeadline             = flag.Duration("http_deadline", time.Second*10, "Deadline for HTTP requests.")
 	maskInternalErrors       = flag.Bool("mask_internal_errors", false, "Don't return error strings with Internal Server Error HTTP responses.")
@@ -67,7 +67,6 @@ var (
 	privKeyFile              = flag.String("private_key", "", "Location of private key file. If unset, uses the contents of the LOG_PRIVATE_KEY environment variable.")
 )
 
-// nolint:staticcheck
 func main() {
 	klog.InitFlags(nil)
 	flag.Parse()
@@ -164,7 +163,7 @@ func newStorage(ctx context.Context, signer note.Signer) (*storage.CTStorage, er
 		return nil, fmt.Errorf("failed to initialize GCP Tessera appender: %v", err)
 	}
 
-	issuerStorage, err := posix.NewIssuerStorage(ctx, *storageDir, "fingerprints/", "application/pkix-cert")
+	issuerStorage, err := posix.NewIssuerStorage(ctx, *storageDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize GCP issuer storage: %v", err)
 	}

--- a/cmd/experimental/posix/main.go
+++ b/cmd/experimental/posix/main.go
@@ -1,0 +1,219 @@
+// Copyright 2016 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The ct_server binary runs the CT personality.
+package main
+
+import (
+	"context"
+	"crypto"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/transparency-dev/tessera"
+	tposix "github.com/transparency-dev/tessera/storage/posix"
+	tposix_as "github.com/transparency-dev/tessera/storage/posix/antispam"
+	"github.com/transparency-dev/tesseract"
+	"github.com/transparency-dev/tesseract/storage"
+	"github.com/transparency-dev/tesseract/storage/posix"
+	"golang.org/x/mod/sumdb/note"
+	"k8s.io/klog/v2"
+)
+
+func init() {
+	flag.Var(&notAfterStart, "not_after_start", "Start of the range of acceptable NotAfter values, inclusive. Leaving this unset implies no lower bound to the range. RFC3339 UTC format, e.g: 2024-01-02T15:04:05Z.")
+	flag.Var(&notAfterLimit, "not_after_limit", "Cut off point of notAfter dates - only notAfter dates strictly *before* notAfterLimit will be accepted. Leaving this unset means no upper bound on the accepted range. RFC3339 UTC format, e.g: 2024-01-02T15:04:05Z.")
+}
+
+// Global flags that affect all log instances.
+var (
+	notAfterStart timestampFlag
+	notAfterLimit timestampFlag
+
+	enablePublicationAwaiter = flag.Bool("enable_publication_awaiter", false, "If true then the certificate is integrated into log before returning the response.")
+	httpEndpoint             = flag.String("http_endpoint", "localhost:6962", "Endpoint for HTTP (host:port).")
+	httpDeadline             = flag.Duration("http_deadline", time.Second*10, "Deadline for HTTP requests.")
+	maskInternalErrors       = flag.Bool("mask_internal_errors", false, "Don't return error strings with Internal Server Error HTTP responses.")
+	origin                   = flag.String("origin", "", "Origin of the log, for checkpoints and the monitoring prefix.")
+	storageDir               = flag.String("storage_dir", "", "Path to root of log storage.")
+	pushbackMaxOutstanding   = flag.Uint("pushback_max_outstanding", tessera.DefaultPushbackMaxOutstanding, "Maximum number of number of in-flight add requests - i.e. the number of entries with sequence numbers assigned, but which are not yet integrated into the log.")
+	rootsPemFile             = flag.String("roots_pem_file", "", "Path to the file containing root certificates that are acceptable to the log. The certs are served through get-roots endpoint.")
+	rejectExpired            = flag.Bool("reject_expired", false, "If true then the certificate validity period will be checked against the current time during the validation of submissions. This will cause expired certificates to be rejected.")
+	rejectUnexpired          = flag.Bool("reject_unexpired", false, "If true then CTFE rejects certificates that are either currently valid or not yet valid.")
+	extKeyUsages             = flag.String("ext_key_usages", "", "If set, will restrict the set of such usages that the server will accept. By default all are accepted. The values specified must be ones known to the x509 package.")
+	rejectExtensions         = flag.String("reject_extension", "", "A list of X.509 extension OIDs, in dotted string form (e.g. '2.3.4.5') which, if present, should cause submissions to be rejected.")
+	privKeyFile              = flag.String("private_key", "", "Location of private key file. If unset, uses the contents of the LOG_PRIVATE_KEY environment variable.")
+)
+
+// nolint:staticcheck
+func main() {
+	klog.InitFlags(nil)
+	flag.Parse()
+	ctx := context.Background()
+
+	signer := signerFromFlags()
+
+	chainValidationConfig := tesseract.ChainValidationConfig{
+		RootsPEMFile:     *rootsPemFile,
+		RejectExpired:    *rejectExpired,
+		RejectUnexpired:  *rejectUnexpired,
+		ExtKeyUsages:     *extKeyUsages,
+		RejectExtensions: *rejectExtensions,
+		NotAfterStart:    notAfterStart.t,
+		NotAfterLimit:    notAfterLimit.t,
+	}
+
+	logHandler, err := tesseract.NewLogHandler(ctx, *origin, signer, chainValidationConfig, newStorage, *httpDeadline, *maskInternalErrors)
+	if err != nil {
+		klog.Exitf("Can't initialize CT HTTP Server: %v", err)
+	}
+
+	klog.CopyStandardLogTo("WARNING")
+	klog.Info("**** CT HTTP Server Starting ****")
+	http.Handle("/", logHandler)
+
+	// Bring up the HTTP server and serve until we get a signal not to.
+	srv := http.Server{Addr: *httpEndpoint}
+	shutdownWG := new(sync.WaitGroup)
+	go awaitSignal(func() {
+		shutdownWG.Add(1)
+		defer shutdownWG.Done()
+		// Allow 60s for any pending requests to finish then terminate any stragglers
+		// TODO(phboneff): maybe wait for the sequencer queue to be empty?
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
+		defer cancel()
+		klog.Info("Shutting down HTTP server...")
+		if err := srv.Shutdown(ctx); err != nil {
+			klog.Errorf("srv.Shutdown(): %v", err)
+		}
+		klog.Info("HTTP server shutdown")
+	})
+
+	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
+		klog.Warningf("Server exited: %v", err)
+	}
+	// Wait will only block if the function passed to awaitSignal was called,
+	// in which case it'll block until the HTTP server has gracefully shutdown
+	shutdownWG.Wait()
+	klog.Flush()
+}
+
+// awaitSignal waits for standard termination signals, then runs the given
+// function; it should be run as a separate goroutine.
+func awaitSignal(doneFn func()) {
+	// Arrange notification for the standard set of signals used to terminate a server
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+	// Now block main and wait for a signal
+	sig := <-sigs
+	klog.Warningf("Signal received: %v", sig)
+	klog.Flush()
+
+	doneFn()
+}
+
+func newStorage(ctx context.Context, signer note.Signer) (*storage.CTStorage, error) {
+	if *storageDir == "" {
+		return nil, errors.New("missing storage_dir")
+	}
+
+	driver, err := tposix.New(ctx, *storageDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize POSIX Tessera storage driver: %v", err)
+	}
+	asOpts := tposix_as.AntispamOpts{}
+	antispam, err := tposix_as.NewAntispam(ctx, filepath.Join(*storageDir, ".state", "antispam"), asOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize POSIX antispam database: %v", err)
+	}
+
+	opts := tessera.NewAppendOptions().
+		WithCheckpointSigner(signer).
+		WithCTLayout().
+		WithAntispam(uint(250<<10), antispam).
+		WithBatching(256, 500*time.Millisecond).
+		WithPushback(*pushbackMaxOutstanding)
+
+	// TODO(phbnf): figure out the best way to thread the `shutdown` func NewAppends returns back out to main so we can cleanly close Tessera down
+	// when it's time to exit.
+	appender, _, reader, err := tessera.NewAppender(ctx, driver, opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize GCP Tessera appender: %v", err)
+	}
+
+	issuerStorage, err := posix.NewIssuerStorage(ctx, *storageDir, "fingerprints/", "application/pkix-cert")
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize GCP issuer storage: %v", err)
+	}
+
+	return storage.NewCTStorage(ctx, appender, issuerStorage, reader, *enablePublicationAwaiter)
+}
+
+type timestampFlag struct {
+	t *time.Time
+}
+
+func (t *timestampFlag) String() string {
+	if t.t != nil {
+		return t.t.Format(time.RFC3339)
+	}
+	return ""
+}
+
+func (t *timestampFlag) Set(w string) error {
+	if !strings.HasSuffix(w, "Z") {
+		return fmt.Errorf("timestamps MUST be in UTC, got %v", w)
+	}
+	tt, err := time.Parse(time.RFC3339, w)
+	if err != nil {
+		return fmt.Errorf("can't parse %q as RFC3339 timestamp: %v", w, err)
+	}
+	t.t = &tt
+	return nil
+}
+
+func signerFromFlags() crypto.Signer {
+	kf := *privKeyFile
+	if kf == "" {
+		kf = os.Getenv("LOG_PRIVATE_KEY")
+	}
+	if kf == "" {
+		klog.Exitf("Must specify --priv_key or LOG_PRIVATE_KEY environment variable.")
+	}
+	r, err := os.ReadFile(kf)
+	if err != nil {
+		klog.Exitf("Failed to read private key from %q: %v", kf, err)
+	}
+	block, _ := pem.Decode(r)
+	if err != nil {
+		klog.Exitf("Failed to parse PEM private key: %v", err)
+	}
+	k, err := x509.ParseECPrivateKey(block.Bytes)
+	if err != nil {
+		klog.Exitf("Failed to parse private key: %v", err)
+	}
+	return k
+}

--- a/storage/posix/file_ops.go
+++ b/storage/posix/file_ops.go
@@ -1,0 +1,157 @@
+// Copyright 2025 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package posix
+
+import (
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	dirPerm  = 0o755
+	filePerm = 0o644
+)
+
+// syncDir calls fsync on the provided path.
+//
+// This is intended to be used to sync directories in which we've just created new entries.
+func syncDir(d string) error {
+	fd, err := os.Open(d)
+	if err != nil {
+		return fmt.Errorf("failed to open %q: %v", d, err)
+	}
+
+	if err := fd.Sync(); err != nil {
+		return fmt.Errorf("failed to sync %q: %v", d, err)
+	}
+	return fd.Close()
+}
+
+// mkdirAll is a reimplementation of os.mkdirAll but where we fsync the parent directory/ies
+// we modify.
+func mkdirAll(name string, perm os.FileMode) (err error) {
+	name = strings.TrimSuffix(name, string(filepath.Separator))
+	if name == "" {
+		return nil
+	}
+
+	// Finally, check and create the dir if necessary.
+	dir, _ := filepath.Split(name)
+	di, err := os.Lstat(name)
+	switch {
+	case errors.Is(err, syscall.ENOENT):
+		// We'll see an ENOENT if there's a problem with a non-existant path element, so
+		// we'll recurse and create the parent directory if necessary.
+		if dir != "" {
+			if err := mkdirAll(dir, perm); err != nil {
+				return err
+			}
+		}
+		// Once we've successfully created the parent element(s), we can drop through and
+		// create the final entry in the requested path.
+		fallthrough
+	case errors.Is(err, os.ErrNotExist):
+		// We'll see ErrNotExist if the final entry in the requested path doesn't exist,
+		// so we simply attempt to create it in here.
+		if err := os.Mkdir(name, perm); err != nil {
+			return fmt.Errorf("%q: %v", name, err)
+		}
+		// And be sure to sync the parent directory.
+		return syncDir(dir)
+	case err != nil:
+		return fmt.Errorf("lstat %q: %v", name, err)
+	case !di.IsDir():
+		return fmt.Errorf("%s is not a directory", name)
+	default:
+		return nil
+	}
+}
+
+// createEx atomically creates a file at the given path containing the provided data, and syncs the
+// directory containing the newly created file.
+//
+// Returns an error if a file already exists at the specified location, or it's unable to fully write the
+// data & close the file.
+func createEx(name string, d []byte) error {
+	dir, _ := filepath.Split(name)
+	if err := mkdirAll(dir, dirPerm); err != nil {
+		return fmt.Errorf("failed to make entries directory structure: %w", err)
+	}
+
+	tmpName, err := createTemp(name, d)
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %v", err)
+	}
+	defer func() {
+		if err := os.Remove(tmpName); err != nil {
+			klog.Warningf("Failed to remove temporary file %q: %v", tmpName, err)
+		}
+	}()
+
+	if err := os.Link(tmpName, name); err != nil {
+		// Wrap the error here because we need to know if it's os.ErrExists at higher levels.
+		return fmt.Errorf("failed to link temporary file to target %q: %w", name, err)
+	}
+
+	return syncDir(dir)
+}
+
+// createTemp creates a new temporary file in the directory dir, with a name based on the provided prefix,
+// and writes the provided data to it.
+//
+// Multiple programs or goroutines calling CreateTemp simultaneously will not choose the same file.
+// It is the caller's responsibility to remove the file when it is no longer needed.
+//
+// Ths file data is written with O_SYNC, however the containing directory is NOT sync'd on the assumption
+// that this temporary file will be linked/renamed by the caller who will also sync the directory.
+func createTemp(prefix string, d []byte) (name string, err error) {
+	try := 0
+	var f *os.File
+
+	for {
+		name = prefix + strconv.Itoa(int(rand.Int32()))
+		f, err = os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_EXCL|os.O_SYNC, filePerm)
+		if err == nil {
+			break
+		} else if os.IsExist(err) {
+			if try++; try < 10000 {
+				continue
+			}
+			return "", &os.PathError{Op: "createtemp", Path: prefix + "*", Err: os.ErrExist}
+		}
+	}
+
+	defer func() {
+		if errC := f.Close(); errC != nil && err == nil {
+			err = errC
+		}
+	}()
+
+	if n, err := f.Write(d); err != nil {
+		return "", fmt.Errorf("failed to write to temporary file %q: %v", name, err)
+	} else if l := len(d); n < l {
+		return "", fmt.Errorf("short write on %q, %d < %d", name, n, l)
+	}
+
+	return name, nil
+}

--- a/storage/posix/issuers.go
+++ b/storage/posix/issuers.go
@@ -1,0 +1,67 @@
+// Copyright 2025 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package posix
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/transparency-dev/tesseract/storage"
+)
+
+// IssuersStorage is a key value store backed by files to store issuer chains.
+type IssuersStorage struct {
+	dir          string
+	prefix       string
+	contentType  string
+	knownIssuers sync.Map
+}
+
+// NewIssuerStorage creates a new GCSStorage.
+//
+// The specified bucket must exist or an error will be returned.
+func NewIssuerStorage(ctx context.Context, dir string, prefix string, contentType string) (*IssuersStorage, error) {
+	r := &IssuersStorage{
+		dir:         dir,
+		prefix:      prefix,
+		contentType: contentType,
+	}
+
+	return r, nil
+}
+
+// AddIssuers stores Issuers values under their Key if there isn't an object under Key already.
+func (s *IssuersStorage) AddIssuersIfNotExist(ctx context.Context, kv []storage.KV) error {
+	errs := make([]error, 0)
+	for _, kv := range kv {
+		k := string(kv.K)
+		_, exists := s.knownIssuers.Load(k)
+		if exists {
+			continue
+		}
+		p := filepath.Join(s.dir, s.prefix, k)
+		if err := createEx(p, kv.V); err != nil {
+			if !errors.Is(err, os.ErrExist) {
+				errs = append(errs, err)
+				continue
+			}
+		}
+		s.knownIssuers.Store(k, struct{}{})
+	}
+	return errors.Join(errs...)
+}


### PR DESCRIPTION
This PR adds an experimental POSIX based CT server.

This server uses Tessera's POSIX backend to store the log on a local filesystem, and implements a POSIX backed store for issuers.

It's been very briefly tested running on a local machine with the preloader (up to about 0.5M entries, at about 2k entries/s)