### PR TITLE
[arche2025h1,arche2025h2,aws-ci,gcp-ci,binaries] enable publication awaiter

### DIFF
--- a/cmd/aws/main.go
+++ b/cmd/aws/main.go
@@ -59,7 +59,7 @@ var (
 	rejectUnexpired          = flag.Bool("reject_unexpired", false, "If true then TesseraCT rejects certificates that are either currently valid or not yet valid.")
 	extKeyUsages             = flag.String("ext_key_usages", "", "If set, will restrict the set of such usages that the server will accept. By default all are accepted. The values specified must be ones known to the x509 package.")
 	rejectExtensions         = flag.String("reject_extension", "", "A list of X.509 extension OIDs, in dotted string form (e.g. '2.3.4.5') which, if present, should cause submissions to be rejected.")
-	enablePublicationAwaiter = flag.Bool("enable_publication_awaiter", false, "If true then the certificate is integrated into log before returning the response.")
+	enablePublicationAwaiter = flag.Bool("enable_publication_awaiter", true, "If true then the certificate is integrated into log before returning the response.")
 
 	// Performance flags
 	httpDeadline              = flag.Duration("http_deadline", time.Second*10, "Deadline for HTTP requests.")

--- a/cmd/gcp/main.go
+++ b/cmd/gcp/main.go
@@ -59,7 +59,7 @@ var (
 	rejectUnexpired          = flag.Bool("reject_unexpired", false, "If true then TesseraCT rejects certificates that are either currently valid or not yet valid.")
 	extKeyUsages             = flag.String("ext_key_usages", "", "If set, will restrict the set of such usages that the server will accept. By default all are accepted. The values specified must be ones known to the x509 package.")
 	rejectExtensions         = flag.String("reject_extension", "", "A list of X.509 extension OIDs, in dotted string form (e.g. '2.3.4.5') which, if present, should cause submissions to be rejected.")
-	enablePublicationAwaiter = flag.Bool("enable_publication_awaiter", false, "If true then the certificate is integrated into log before returning the response.")
+	enablePublicationAwaiter = flag.Bool("enable_publication_awaiter", true, "If true then the certificate is integrated into log before returning the response.")
 
 	// Performance flags
 	httpDeadline              = flag.Duration("http_deadline", time.Second*10, "Deadline for HTTP requests.")

--- a/deployment/live/gcp/static-ct-staging/logs/arche2025h1/terragrunt.hcl
+++ b/deployment/live/gcp/static-ct-staging/logs/arche2025h1/terragrunt.hcl
@@ -3,16 +3,15 @@ terraform {
 }
 
 locals {
-  env                 = include.root.locals.env
-  docker_env          = local.env
-  base_name           = include.root.locals.base_name
-  origin_suffix       = include.root.locals.origin_suffix
-  not_after_start     = "2025-01-01T00:00:00Z"
-  not_after_limit     = "2025-07-01T00:00:00Z"
-  server_docker_image = "${include.root.locals.location}-docker.pkg.dev/${include.root.locals.project_id}/docker-${local.env}/tesseract-gcp:${include.root.locals.docker_container_tag}"
-  spanner_pu          = 500
-  trace_fraction      = 0.1
-  machine_type        = "n2-standard-4"
+  env                        = include.root.locals.env
+  docker_env                 = local.env
+  base_name                  = include.root.locals.base_name
+  origin_suffix              = include.root.locals.origin_suffix
+  not_after_start            = "2025-01-01T00:00:00Z"
+  not_after_limit            = "2025-07-01T00:00:00Z"
+  server_docker_image        = "${include.root.locals.location}-docker.pkg.dev/${include.root.locals.project_id}/docker-${local.env}/tesseract-gcp:${include.root.locals.docker_container_tag}"
+  spanner_pu                 = 500
+  trace_fraction             = 0.1
 }
 
 include "root" {

--- a/deployment/live/gcp/static-ct-staging/logs/arche2025h2/terragrunt.hcl
+++ b/deployment/live/gcp/static-ct-staging/logs/arche2025h2/terragrunt.hcl
@@ -3,16 +3,15 @@ terraform {
 }
 
 locals {
-  env                 = include.root.locals.env
-  docker_env          = local.env
-  base_name           = include.root.locals.base_name
-  origin_suffix       = include.root.locals.origin_suffix
-  not_after_start     = "2025-07-01T00:00:00Z"
-  not_after_limit     = "2026-01-01T00:00:00Z"
-  server_docker_image = "${include.root.locals.location}-docker.pkg.dev/${include.root.locals.project_id}/docker-${local.env}/tesseract-gcp:${include.root.locals.docker_container_tag}"
-  spanner_pu          = 500
-  trace_fraction      = 0.1
-  machine_type        = "n2-standard-4"
+  env                        = include.root.locals.env
+  docker_env                 = local.env
+  base_name                  = include.root.locals.base_name
+  origin_suffix              = include.root.locals.origin_suffix
+  not_after_start            = "2025-07-01T00:00:00Z"
+  not_after_limit            = "2026-01-01T00:00:00Z"
+  server_docker_image        = "${include.root.locals.location}-docker.pkg.dev/${include.root.locals.project_id}/docker-${local.env}/tesseract-gcp:${include.root.locals.docker_container_tag}"
+  spanner_pu                 = 500
+  trace_fraction             = 0.1
 }
 
 include "root" {

--- a/deployment/modules/aws/tesseract/conformance/main.tf
+++ b/deployment/modules/aws/tesseract/conformance/main.tf
@@ -173,6 +173,7 @@ resource "aws_ecs_task_definition" "conformance" {
       "--signer_private_key_secret_name=${module.secretsmanager.ecdsa_p256_private_key_id}",
       "--antispam_db_name=${var.antispam_database_name}",
       "--inmemory_antispam_cache_size=256k",
+      "--enable_publication_awaiter=true",
       "-v=2"
     ],
     "logConfiguration" : {

--- a/deployment/modules/gcp/cloudrun/variables.tf
+++ b/deployment/modules/gcp/cloudrun/variables.tf
@@ -75,10 +75,10 @@ variable "trace_fraction" {
 
 variable "batch_max_size" {
   description = "Maximum number of entries to process in a single sequencing batch."
-  type = number
+  type        = number
 }
 
 variable "batch_max_age" {
   description = "Maximum age of entries in a single sequencing batch."
-  type = string
+  type        = string
 }

--- a/deployment/modules/gcp/gce/tesseract/main.tf
+++ b/deployment/modules/gcp/gce/tesseract/main.tf
@@ -39,6 +39,7 @@ module "gce_container_tesseract" {
       "--trace_fraction=${var.trace_fraction}",
       "--batch_max_size=${var.batch_max_size}",
       "--batch_max_age=${var.batch_max_age}",
+      "--enable_publication_awaiter=${var.enable_publication_awaiter}"
     ]
     tty : true # maybe remove this
   }

--- a/deployment/modules/gcp/gce/tesseract/variables.tf
+++ b/deployment/modules/gcp/gce/tesseract/variables.tf
@@ -95,7 +95,7 @@ variable "batch_max_age" {
 }
 
 variable "enable_publication_awaiter" {
-  description = "If true, waits for certificates to be integrated into the log log before returning an SCT."
+  description = "If true, waits for certificates to be integrated into the log before returning an SCT."
   type        = bool
   default     = true
 }

--- a/deployment/modules/gcp/gce/tesseract/variables.tf
+++ b/deployment/modules/gcp/gce/tesseract/variables.tf
@@ -84,12 +84,18 @@ variable "trace_fraction" {
 
 variable "batch_max_size" {
   description = "Maximum number of entries to process in a single sequencing batch."
-  type = number
-  default = 1024
+  type        = number
+  default     = 1024
 }
 
 variable "batch_max_age" {
   description = "Maximum age of entries in a single sequencing batch."
-  type = string
-  default = "500ms"
+  type        = string
+  default     = "500ms"
+}
+
+variable "enable_publication_awaiter" {
+  description = "If true, waits for certificates to be integrated into the log log before returning an SCT."
+  type        = bool
+  default     = true
 }

--- a/deployment/modules/gcp/tesseract/cloudrun/variables.tf
+++ b/deployment/modules/gcp/tesseract/cloudrun/variables.tf
@@ -53,14 +53,14 @@ variable "spanner_pu" {
 
 variable "batch_max_size" {
   description = "Maximum number of entries to process in a single sequencing batch."
-  type = number
-  default = 1024
+  type        = number
+  default     = 1024
 }
 
 variable "batch_max_age" {
   description = "Maximum age of entries in a single sequencing batch."
-  type = string
-  default = "500ms"
+  type        = string
+  default     = "500ms"
 }
 
 variable "ephemeral" {

--- a/deployment/modules/gcp/tesseract/gce/main.tf
+++ b/deployment/modules/gcp/tesseract/gce/main.tf
@@ -39,6 +39,7 @@ module "gce" {
   trace_fraction                 = var.trace_fraction
   batch_max_age                  = var.batch_max_age
   batch_max_size                 = var.batch_max_size
+  enable_publication_awaiter     = var.enable_publication_awaiter
 
   depends_on = [
     module.secretmanager,

--- a/deployment/modules/gcp/tesseract/gce/variables.tf
+++ b/deployment/modules/gcp/tesseract/gce/variables.tf
@@ -82,7 +82,7 @@ variable "trace_fraction" {
 }
 
 variable "enable_publication_awaiter" {
-  description = "If true, waits for certificates to be integrated into the log log before returning an SCT."
+  description = "If true, waits for certificates to be integrated into the log before returning an SCT."
   type        = bool
   default     = true
 }

--- a/deployment/modules/gcp/tesseract/gce/variables.tf
+++ b/deployment/modules/gcp/tesseract/gce/variables.tf
@@ -47,25 +47,26 @@ variable "server_docker_image" {
 
 variable "machine_type" {
   description = "GCP Compute Engine machine type to run the TesseraCT container on"
-  type = string
+  type        = string
+  default     = "n2-standard-4"
 }
 
 variable "spanner_pu" {
   description = "Amount of Spanner processing units"
-  type = number
-  default = 100
+  type        = number
+  default     = 100
 }
 
 variable "batch_max_size" {
   description = "Maximum number of entries to process in a single sequencing batch."
-  type = number
-  default = 1024
+  type        = number
+  default     = 1024
 }
 
 variable "batch_max_age" {
   description = "Maximum age of entries in a single sequencing batch."
-  type = string
-  default = "500ms"
+  type        = string
+  default     = "500ms"
 }
 
 variable "ephemeral" {
@@ -78,4 +79,10 @@ variable "trace_fraction" {
   description = "Fraction of open-telemetry span traces to sample."
   default     = 0
   type        = number
+}
+
+variable "enable_publication_awaiter" {
+  description = "If true, waits for certificates to be integrated into the log log before returning an SCT."
+  type        = bool
+  default     = true
 }


### PR DESCRIPTION
This PR enables the publication awaiter by default, and make this configurable on GCE instances.
I don't really like that default values are defined in 3 places (binaries, base terraform for TesseraCT servers, terraform for TesseraCT service), we'll find a better solution later and apply it to all flags.

While I'm there, format a few variables files.