### PR TITLE
Bump GCP CI Cloud Build timeout to 20 minutes

### DIFF
--- a/deployment/modules/gcp/cloudbuild/conformance/main.tf
+++ b/deployment/modules/gcp/cloudbuild/conformance/main.tf
@@ -58,6 +58,8 @@ resource "google_cloudbuild_trigger" "build_trigger" {
   }
 
   build {
+    timeout = "20m"
+
     ## Install Terragrunt and OpenTofu in alpine container.
     step {
       id   = "prepare_terragrunt_opentofu_container"


### PR DESCRIPTION
The default timeout is 10 minutes for each build. Bumping it to 20 minutes should fix the timeout issue caused by the long Spanner creation time.