### PR TITLE
Health Checks

### DIFF
--- a/deployment/live/gcp/static-ct-staging/preloaders/root.hcl
+++ b/deployment/live/gcp/static-ct-staging/preloaders/root.hcl
@@ -4,7 +4,7 @@ locals {
   location            = get_env("GOOGLE_REGION", "us-central1")
   base_name           = path_relative_to_include()
   github_owner        = get_env("GITHUB_OWNER", "transparency-dev")
-  target_log_uri      = get_env("TARGET_LOG_URI", "http://${local.base_name}.${local.base_name}-ilb.il4.${local.location}.lb.${local.project_id}.internal:6962/${local.base_name}.staging.ct.transparency.dev/")
+  target_log_uri      = get_env("TARGET_LOG_URI", "http://${local.base_name}.${local.base_name}-ilb.il4.${local.location}.lb.${local.project_id}.internal:80/${local.base_name}.staging.ct.transparency.dev/")
   server_docker_image = "us-central1-docker.pkg.dev/static-ct-staging/docker-staging/preloader:latest"
 }
 

--- a/deployment/modules/gcp/gce/tesseract/main.tf
+++ b/deployment/modules/gcp/gce/tesseract/main.tf
@@ -160,8 +160,10 @@ module "gce_ilb" {
   ports       = ["80"]
   source_tags = []
   // TODO(phbnf): come back to this, it doesn't match with the VM tags.
-  target_tags   = ["${var.base_name}-allow-group"]
-  service_label = var.base_name
+  target_tags                  = []
+  service_label                = var.base_name
+  create_backend_firewall      = false
+  create_health_check_firewall = false
 
   health_check = {
     type                = "http"

--- a/deployment/modules/gcp/gce/tesseract/main.tf
+++ b/deployment/modules/gcp/gce/tesseract/main.tf
@@ -110,6 +110,10 @@ resource "google_compute_health_check" "healthz" {
     response     = "ok"
     port         = 80
   }
+
+  log_config {
+    enable = true
+  }
 }
 
 resource "google_compute_region_instance_group_manager" "instance_group_manager" {


### PR DESCRIPTION
Towards #104 

This PR enables health checks and auto-healing by:
 - switching the server port from 6962 to 80 (to match with firewall policies)
 - sets the right network tags
 - changes the name of the mig health checks to match with the ilb ones