### PR TITLE
Prefix flag

### DIFF
--- a/cmd/tesseract/aws/main.go
+++ b/cmd/tesseract/aws/main.go
@@ -54,7 +54,7 @@ var (
 	httpEndpoint             = flag.String("http_endpoint", "localhost:6962", "Endpoint for HTTP (host:port).")
 	maskInternalErrors       = flag.Bool("mask_internal_errors", false, "Don't return error strings with Internal Server Error HTTP responses.")
 	origin                   = flag.String("origin", "", "Origin of the log, for checkpoints.")
-	pathPrefix               = flag.String("path_prefix", "", "Prefix to use on the submission URL: HOST:PATH_PREFIX/ct/v1/ENDPOINT.")
+	pathPrefix               = flag.String("path_prefix", "", "Prefix to use on endpoints URL paths: HOST:PATH_PREFIX/ct/v1/ENDPOINT.")
 	rootsPemFile             = flag.String("roots_pem_file", "", "Path to the file containing root certificates that are acceptable to the log. The certs are served through get-roots endpoint.")
 	rejectExpired            = flag.Bool("reject_expired", false, "If true then the certificate validity period will be checked against the current time during the validation of submissions. This will cause expired certificates to be rejected.")
 	rejectUnexpired          = flag.Bool("reject_unexpired", false, "If true then TesseraCT rejects certificates that are either currently valid or not yet valid.")

--- a/cmd/tesseract/aws/main.go
+++ b/cmd/tesseract/aws/main.go
@@ -53,7 +53,8 @@ var (
 	// Functionality flags
 	httpEndpoint             = flag.String("http_endpoint", "localhost:6962", "Endpoint for HTTP (host:port).")
 	maskInternalErrors       = flag.Bool("mask_internal_errors", false, "Don't return error strings with Internal Server Error HTTP responses.")
-	origin                   = flag.String("origin", "", "Origin of the log, for checkpoints and the monitoring prefix.")
+	origin                   = flag.String("origin", "", "Origin of the log, for checkpoints.")
+	pathPrefix               = flag.String("path_prefix", "", "Prefix to use on the submission URL: HOST:PATH_PREFIX/ct/v1/ENDPOINT.")
 	rootsPemFile             = flag.String("roots_pem_file", "", "Path to the file containing root certificates that are acceptable to the log. The certs are served through get-roots endpoint.")
 	rejectExpired            = flag.Bool("reject_expired", false, "If true then the certificate validity period will be checked against the current time during the validation of submissions. This will cause expired certificates to be rejected.")
 	rejectUnexpired          = flag.Bool("reject_unexpired", false, "If true then TesseraCT rejects certificates that are either currently valid or not yet valid.")
@@ -105,7 +106,7 @@ func main() {
 		NotAfterLimit:    notAfterLimit.t,
 	}
 
-	logHandler, err := tesseract.NewLogHandler(ctx, *origin, signer, chainValidationConfig, newAWSStorage, *httpDeadline, *maskInternalErrors)
+	logHandler, err := tesseract.NewLogHandler(ctx, *origin, signer, chainValidationConfig, newAWSStorage, *httpDeadline, *maskInternalErrors, *pathPrefix)
 	if err != nil {
 		klog.Exitf("Can't initialize CT HTTP Server: %v", err)
 	}

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -54,7 +54,8 @@ var (
 	// Functionality flags
 	httpEndpoint             = flag.String("http_endpoint", "localhost:6962", "Endpoint for HTTP (host:port).")
 	maskInternalErrors       = flag.Bool("mask_internal_errors", false, "Don't return error strings with Internal Server Error HTTP responses.")
-	origin                   = flag.String("origin", "", "Origin of the log, for checkpoints and the monitoring prefix.")
+	origin                   = flag.String("origin", "", "Origin of the log, for checkpoints.")
+	pathPrefix               = flag.String("path_prefix", "", "Prefix to use on the submission URL: HOST:PATH_PREFIX/ct/v1/ENDPOINT.")
 	rootsPemFile             = flag.String("roots_pem_file", "", "Path to the file containing root certificates that are acceptable to the log. The certs are served through get-roots endpoint.")
 	rejectExpired            = flag.Bool("reject_expired", false, "If true then the certificate validity period will be checked against the current time during the validation of submissions. This will cause expired certificates to be rejected.")
 	rejectUnexpired          = flag.Bool("reject_unexpired", false, "If true then TesseraCT rejects certificates that are either currently valid or not yet valid.")
@@ -108,7 +109,7 @@ func main() {
 		NotAfterLimit:    notAfterLimit.t,
 	}
 
-	logHandler, err := tesseract.NewLogHandler(ctx, *origin, signer, chainValidationConfig, newGCPStorage, *httpDeadline, *maskInternalErrors)
+	logHandler, err := tesseract.NewLogHandler(ctx, *origin, signer, chainValidationConfig, newGCPStorage, *httpDeadline, *maskInternalErrors, *pathPrefix)
 	if err != nil {
 		klog.Exitf("Can't initialize CT HTTP Server: %v", err)
 	}

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -55,7 +55,7 @@ var (
 	httpEndpoint             = flag.String("http_endpoint", "localhost:6962", "Endpoint for HTTP (host:port).")
 	maskInternalErrors       = flag.Bool("mask_internal_errors", false, "Don't return error strings with Internal Server Error HTTP responses.")
 	origin                   = flag.String("origin", "", "Origin of the log, for checkpoints.")
-	pathPrefix               = flag.String("path_prefix", "", "Prefix to use on the submission URL: HOST:PATH_PREFIX/ct/v1/ENDPOINT.")
+	pathPrefix               = flag.String("path_prefix", "", "Prefix to use on endpoints URL paths: HOST:PATH_PREFIX/ct/v1/ENDPOINT.")
 	rootsPemFile             = flag.String("roots_pem_file", "", "Path to the file containing root certificates that are acceptable to the log. The certs are served through get-roots endpoint.")
 	rejectExpired            = flag.Bool("reject_expired", false, "If true then the certificate validity period will be checked against the current time during the validation of submissions. This will cause expired certificates to be rejected.")
 	rejectUnexpired          = flag.Bool("reject_unexpired", false, "If true then TesseraCT rejects certificates that are either currently valid or not yet valid.")

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -56,7 +56,8 @@ var (
 	httpEndpoint              = flag.String("http_endpoint", "localhost:6962", "Endpoint for HTTP (host:port).")
 	httpDeadline              = flag.Duration("http_deadline", time.Second*10, "Deadline for HTTP requests.")
 	maskInternalErrors        = flag.Bool("mask_internal_errors", false, "Don't return error strings with Internal Server Error HTTP responses.")
-	origin                    = flag.String("origin", "", "Origin of the log, for checkpoints and the monitoring prefix.")
+	origin                    = flag.String("origin", "", "Origin of the log, for checkpoints.")
+	pathPrefix                = flag.String("path_prefix", "", "Prefix to use on the submission URL: HOST:PATH_PREFIX/ct/v1/ENDPOINT.")
 	storageDir                = flag.String("storage_dir", "", "Path to root of log storage.")
 	pushbackMaxOutstanding    = flag.Uint("pushback_max_outstanding", tessera.DefaultPushbackMaxOutstanding, "Maximum number of number of in-flight add requests - i.e. the number of entries with sequence numbers assigned, but which are not yet integrated into the log.")
 	pushbackMaxDedupeInFlight = flag.Uint("pushback_max_dedupe_in_flight", 100, "Maximum number of number of in-flight duplicate add requests - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always pushed back.")
@@ -89,7 +90,7 @@ func main() {
 		NotAfterLimit:    notAfterLimit.t,
 	}
 
-	logHandler, err := tesseract.NewLogHandler(ctx, *origin, signer, chainValidationConfig, newStorage, *httpDeadline, *maskInternalErrors)
+	logHandler, err := tesseract.NewLogHandler(ctx, *origin, signer, chainValidationConfig, newStorage, *httpDeadline, *maskInternalErrors, *pathPrefix)
 	if err != nil {
 		klog.Exitf("Can't initialize CT HTTP Server: %v", err)
 	}

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -57,7 +57,7 @@ var (
 	httpDeadline              = flag.Duration("http_deadline", time.Second*10, "Deadline for HTTP requests.")
 	maskInternalErrors        = flag.Bool("mask_internal_errors", false, "Don't return error strings with Internal Server Error HTTP responses.")
 	origin                    = flag.String("origin", "", "Origin of the log, for checkpoints.")
-	pathPrefix                = flag.String("path_prefix", "", "Prefix to use on the submission URL: HOST:PATH_PREFIX/ct/v1/ENDPOINT.")
+	pathPrefix                = flag.String("path_prefix", "", "Prefix to use on endpoints URL paths: HOST:PATH_PREFIX/ct/v1/ENDPOINT.")
 	storageDir                = flag.String("storage_dir", "", "Path to root of log storage.")
 	pushbackMaxOutstanding    = flag.Uint("pushback_max_outstanding", tessera.DefaultPushbackMaxOutstanding, "Maximum number of number of in-flight add requests - i.e. the number of entries with sequence numbers assigned, but which are not yet integrated into the log.")
 	pushbackMaxDedupeInFlight = flag.Uint("pushback_max_dedupe_in_flight", 100, "Maximum number of number of in-flight duplicate add requests - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always pushed back.")

--- a/ctlog.go
+++ b/ctlog.go
@@ -121,7 +121,7 @@ func newChainValidator(cfg ChainValidationConfig) (ct.ChainValidator, error) {
 // NewLogHandler creates a Tessera based CT log pluged into HTTP handlers.
 // The HTTP server handlers implement https://c2sp.org/static-ct-api write
 // endpoints.
-func NewLogHandler(ctx context.Context, origin string, signer crypto.Signer, cfg ChainValidationConfig, cs storage.CreateStorage, httpDeadline time.Duration, maskInternalErrors bool) (http.Handler, error) {
+func NewLogHandler(ctx context.Context, origin string, signer crypto.Signer, cfg ChainValidationConfig, cs storage.CreateStorage, httpDeadline time.Duration, maskInternalErrors bool, pathPrefix string) (http.Handler, error) {
 	cv, err := newChainValidator(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("newCertValidationOpts(): %v", err)
@@ -136,6 +136,7 @@ func NewLogHandler(ctx context.Context, origin string, signer crypto.Signer, cfg
 		RequestLog:         &ct.DefaultRequestLog{},
 		MaskInternalErrors: maskInternalErrors,
 		TimeSource:         sysTimeSource,
+		PathPrefix:         pathPrefix,
 	}
 
 	handlers := ct.NewPathHandlers(ctx, opts, log)

--- a/deployment/live/aws/test/README.md
+++ b/deployment/live/aws/test/README.md
@@ -121,6 +121,7 @@ go run ./cmd/tesseract/aws \
   --http_endpoint=localhost:6962 \
   --roots_pem_file=./internal/testdata/fake-ca.cert \
   --origin=test-static-ct \
+  --path_prefix=test-static-ct \
   --bucket=${TESSERACT_BUCKET_NAME} \
   --db_name=tesseract \
   --db_host=${TESSERACT_DB_HOST} \
@@ -212,6 +213,7 @@ go run ./cmd/tesseract/aws \
   --http_endpoint=localhost:6962 \
   --roots_pem_file=/tmp/log_roots.pem \
   --origin=test-static-ct \
+  --path_prefix=test-static-ct \
   --bucket=${TESSERACT_BUCKET_NAME} \
   --db_name=tesseract \
   --db_host=${TESSERACT_DB_HOST} \

--- a/deployment/live/gcp/test/README.md
+++ b/deployment/live/gcp/test/README.md
@@ -101,6 +101,7 @@ go run ./cmd/tesseract/gcp/ \
   --spanner_antispam_db_path=projects/${GOOGLE_PROJECT}/instances/${TESSERA_BASE_NAME}/databases/${TESSERA_BASE_NAME}-antispam-db \
   --roots_pem_file=/tmp/fake_log_roots.pem \
   --origin=${TESSERA_BASE_NAME} \
+  --path_prefix=${TESSERA_BASE_NAME} \
   --signer_public_key_secret_name=${TESSERACT_SIGNER_ECDSA_P256_PUBLIC_KEY_ID} \
   --signer_private_key_secret_name=${TESSERACT_SIGNER_ECDSA_P256_PRIVATE_KEY_ID} \
   --otel_project_id=${GOOGLE_PROJECT}
@@ -188,6 +189,7 @@ go run ./cmd/tesseract/gcp/ \
   --spanner_db_path=projects/${GOOGLE_PROJECT}/instances/${TESSERA_BASE_NAME}/databases/${TESSERA_BASE_NAME}-db \
   --roots_pem_file=/tmp/log_roots.pem \
   --origin=${TESSERA_BASE_NAME} \
+  --path_prefix=${TESSERA_BASE_NAME} \
   --spanner_antispam_db_path=projects/${GOOGLE_PROJECT}/instances/${TESSERA_BASE_NAME}/databases/${TESSERA_BASE_NAME}-antispam-db \
   --signer_public_key_secret_name=${TESSERACT_SIGNER_ECDSA_P256_PUBLIC_KEY_ID} \
   --signer_private_key_secret_name=${TESSERACT_SIGNER_ECDSA_P256_PRIVATE_KEY_ID} \

--- a/deployment/modules/aws/tesseract/conformance/main.tf
+++ b/deployment/modules/aws/tesseract/conformance/main.tf
@@ -163,6 +163,7 @@ resource "aws_ecs_task_definition" "conformance" {
       "--http_endpoint=:${local.port}",
       "--roots_pem_file=/bin/test_root_ca_cert.pem",
       "--origin=ci-static-ct",
+      "--path_prefix=ci-static-ct",
       "--bucket=${module.storage.s3_bucket_name}",
       "--db_user=tesseract",
       "--db_password=${module.storage.rds_aurora_cluster_master_user_secret_unsafe}",

--- a/deployment/modules/gcp/cloudrun/main.tf
+++ b/deployment/modules/gcp/cloudrun/main.tf
@@ -47,6 +47,7 @@ resource "google_cloud_run_v2_service" "default" {
         "--spanner_antispam_db_path=${local.spanner_antispam_db_path}",
         "--roots_pem_file=/bin/test_root_ca_cert.pem",
         "--origin=${var.base_name}${var.origin_suffix}",
+        "--path_prefix=${var.base_name}${var.origin_suffix}",
         "--signer_public_key_secret_name=${var.signer_public_key_secret_name}",
         "--signer_private_key_secret_name=${var.signer_private_key_secret_name}",
         "--inmemory_antispam_cache_size=256k",

--- a/deployment/modules/gcp/gce/tesseract/main.tf
+++ b/deployment/modules/gcp/gce/tesseract/main.tf
@@ -31,6 +31,7 @@ module "gce_container_tesseract" {
       "--spanner_antispam_db_path=${local.spanner_antispam_db_path}",
       "--roots_pem_file=/bin/test_root_ca_cert.pem",
       "--origin=${var.base_name}${var.origin_suffix}",
+      "--path_prefix=${var.base_name}${var.origin_suffix}",
       "--signer_public_key_secret_name=${var.signer_public_key_secret_name}",
       "--signer_private_key_secret_name=${var.signer_private_key_secret_name}",
       "--inmemory_antispam_cache_size=256k",

--- a/internal/ct/handlers.go
+++ b/internal/ct/handlers.go
@@ -194,14 +194,16 @@ type HandlerOptions struct {
 	// TimeSource indicated the system time and can be injfected for testing.
 	// TODO(phbnf): hide inside the log
 	TimeSource TimeSource
+	// PathPrefix prefixes static-ct-api endpoint paths.
+	PathPrefix string
 }
 
 func NewPathHandlers(ctx context.Context, opts *HandlerOptions, log *log) pathHandlers {
 	once.Do(func() { setupMetrics() })
 	knownLogs.Record(ctx, 1, metric.WithAttributes(originKey.String(log.origin)))
 
-	prefix := strings.TrimRight(log.origin, "/")
-	if !strings.HasPrefix(prefix, "/") {
+	prefix := strings.TrimRight(opts.PathPrefix, "/")
+	if prefix != "" && !strings.HasPrefix(prefix, "/") {
 		prefix = "/" + prefix
 	}
 

--- a/internal/ct/handlers_test.go
+++ b/internal/ct/handlers_test.go
@@ -70,6 +70,7 @@ var (
 		RequestLog:         &DefaultRequestLog{},
 		MaskInternalErrors: false,
 		TimeSource:         timeSource,
+		PathPrefix:         prefix,
 	}
 
 	// POSIX subdirectory
@@ -308,7 +309,7 @@ func TestPostHandlersFailure(t *testing.T) {
 func TestNewPathHandlers(t *testing.T) {
 	log, _ := setupTestLog(t)
 	t.Run("Handlers", func(t *testing.T) {
-		handlers := NewPathHandlers(t.Context(), &HandlerOptions{}, log)
+		handlers := NewPathHandlers(t.Context(), &HandlerOptions{PathPrefix: prefix}, log)
 		// Check each entrypoint has a handler
 		if got, want := len(handlers), len(entrypoints); got != want {
 			t.Fatalf("len(info.handler)=%d; want %d", got, want)


### PR DESCRIPTION
Configures path prefix with a dedicated flag rather than using the origin. This allows splitting the origin between the host and the path.