### PR TITLE
Fix links, table, and better instructions for non cloud deployments

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -4,6 +4,9 @@ This directory contains OpenTofu [modules](./modules/) to deploy TesseraCT on
 GCP and AWS with various setups, and the [instantiations](./live/) we use for
 our deployments.
 
+To run TesseraCT on [POSIX](/cmd/tesseract/posix) or [Vanilla S3+MySQL](/cmd/tesseract/aws),
+go to the respective binary documentation directly.
+
 > [!WARNING]
 > These config files are primarily meant to support our own deployments, and to
 > provide a starting point for other deployments. You can fork them, but DO NOT
@@ -24,11 +27,10 @@ Each cloud platform requires its own TesseraCT binary and Tessera
 infrastructure. This table summarizes which cloud providers are supported, and
 on which platform each instantiation runs:
 
-| Cloud | Binary                                      | Test log              | CI logs                                   | Staging logs                                         |
-|-------|---------------------------------------------|-----------------------|-------------------------------------------|------------------------------------------------------|
-| GCP   | [cmd/tesseract/gcp](/cmd/tesseract/gcp)     | [VM](./live/gcp/test) | [Cloud Run](./live/gcp/static-ct/logs/ci) | [Cloud Run / MIG](./live/gcp/static-ct-staging/logs) |
-| AWS   | [cmd/tesseract/aws](/cmd/tesseract/aws)     | [VM](./live/aws/test) | [Fargate](./live/aws/conformance/ci)      |                                                      |
-| POSIX | [cmd/tesseract/posix](/cmd/tesseract/posix) | N/A                   | N/A                                       |                                                      |
+| Cloud   | Binary                                      | Test log              | CI logs                                   | Staging logs                                         |
+|---------|---------------------------------------------|-----------------------|-------------------------------------------|------------------------------------------------------|
+| GCP     | [cmd/tesseract/gcp](/cmd/tesseract/gcp)     | [VM](./live/gcp/test) | [Cloud Run](./live/gcp/static-ct/logs/ci) | [Cloud Run / MIG](./live/gcp/static-ct-staging/logs) |
+| AWS     | [cmd/tesseract/aws](/cmd/tesseract/aws)     | [VM](./live/aws/test) | [Fargate](./live/aws/conformance/ci)      |                                                      |
 
 ## Codelab
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -24,15 +24,14 @@ Each cloud platform requires its own TesseraCT binary and Tessera
 infrastructure. This table summarizes which cloud providers are supported, and
 on which platform each instantiation runs:
 
-| Cloud | Binary                | Test log                         | CI logs                                            | Staging logs                                       |
-|-------|-----------------------|----------------------------------|----------------------------------------------------|----------------------------------------------------|
-| GCP   | [cmd/tesseract/gcp](/cmd/tesseract/gcp)     | [VM](/live/gcp/test)| [Cloud Run](/live/gcp/static-ct/logs/ci)  | [Cloud Run / MIG](/live/gcp/static-ct-staging/logs)|
-| AWS   | [cmd/tesseract/aws](/cmd/tesseract/aws)     | [VM](/live/aws/test)| [Fargate](/live/aws/conformance/ci)       |                                                    |
-| POSIX | [cmd/tesseract/posix](/cmd/tesseract/posix) | N/A                 | N/A                                       |                                                    |
+| Cloud | Binary                                      | Test log              | CI logs                                   | Staging logs                                         |
+|-------|---------------------------------------------|-----------------------|-------------------------------------------|------------------------------------------------------|
+| GCP   | [cmd/tesseract/gcp](/cmd/tesseract/gcp)     | [VM](./live/gcp/test) | [Cloud Run](./live/gcp/static-ct/logs/ci) | [Cloud Run / MIG](./live/gcp/static-ct-staging/logs) |
+| AWS   | [cmd/tesseract/aws](/cmd/tesseract/aws)     | [VM](./live/aws/test) | [Fargate](./live/aws/conformance/ci)      |                                                      |
+| POSIX | [cmd/tesseract/posix](/cmd/tesseract/posix) | N/A                   | N/A                                       |                                                      |
 
 ## Codelab
 
 The [GCP](./live/gcp/test) and [AWS](./live/aws/test) codelabs will guide you
 through bringing up a test TesseraCT log, adding a few entries to it, and check
 that the log is sound.
-


### PR DESCRIPTION
Towards #321 

There isn't any documentation for Vanilla S3 + MySQL, but we'll add that later.