### PR TITLE
Fix broken link to GCP configuration in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ depend on them
 1. Documentation
      <!--Please, keep this in sync with ./docs/README.md -->
      + [Configuration](/cmd/tesseract/)
-       - [GCP](/cmd/tesseract/aws/)
+       - [GCP](/cmd/tesseract/gcp/)
        - [AWS and S3+MySQL](/cmd/tesseract/aws/)
        - [POSIX](/cmd/tesseract/posix/)
      + [Performance](/docs/performance.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 <!--Please, keep this in sync with ../README.md -->
 + [Configuration](/cmd/tesseract/)
-  - [GCP](/cmd/tesseract/aws/)
+  - [GCP](/cmd/tesseract/gcp/)
   - [AWS and S3+MySQL](/cmd/tesseract/aws/)
   - [POSIX](/cmd/tesseract/posix/)
 + [Performance](/docs/performance.md)


### PR DESCRIPTION
The link for GCP configuration in both README.md and docs/README.md was incorrectly pointing to the AWS directory. This was likely a copy-paste error.

This commit corrects the link to point to the correct gcp directory.