### PR TITLE
Update `engine_version` to `8.0` in AWS storage rds terraform

### DIFF
--- a/deployment/modules/aws/storage/main.tf
+++ b/deployment/modules/aws/storage/main.tf
@@ -25,7 +25,7 @@ resource "aws_s3_bucket" "log_bucket" {
 resource "aws_rds_cluster" "log_rds_cluster" {
   cluster_identifier          = "${var.base_name}-cluster"
   engine                      = "aurora-mysql"
-  engine_version              = "8.0.mysql_aurora.3.05.2"
+  engine_version              = "8.0"
   database_name               = "tesseract"
   manage_master_user_password = true
   master_username             = "tesseract"


### PR DESCRIPTION
According to the [hashicorp/aws provider docs](https://search.opentofu.org/provider/hashicorp/aws/latest/docs/resources/rds_cluster#:~:text=engine_version%20%2D%20(Optional)%20Database%20engine%20version.%20Updating%20this%20argument%20results%20in%20an%20outage.), updating this argument results in an outage. The auto minor version upgrade is enabled by default and cannot be configured via Terraform config. Setting the major version to 8.0 without minor version should avoid the below issue caused by auto minor version upgrade.

```
13:31:44.025 STDOUT tofu: OpenTofu used the selected providers to generate the following execution
13:31:44.026 STDOUT tofu: plan. Resource actions are indicated with the following symbols:
13:31:44.026 STDOUT tofu:   ~ update in-place
13:31:44.026 STDOUT tofu:  <= read (data resources)
13:31:44.027 STDOUT tofu: OpenTofu planned the following actions, but then encountered a problem:
13:31:44.027 STDOUT tofu:   # module.storage.data.aws_secretsmanager_secret_version.db_credentials will be read during apply
13:31:44.028 STDOUT tofu:   # (depends on a resource or a module with changes pending)
13:31:44.040 STDERR tofu: ╷
13:31:44.040 STDOUT tofu:  <= data "aws_secretsmanager_secret_version" "db_credentials" {
13:31:44.040 STDOUT tofu:       + arn            = (known after apply)
13:31:44.040 STDERR tofu: │ Error: failed to connect to MySQL: could not create new connection: could not connect to server: Error 1045 (28000): Access denied for user 'tesseract'@'172.31.24.203' (using password: NO)
13:31:44.040 STDOUT tofu:       + created_date   = (known after apply)
13:31:44.040 STDERR tofu: │ 
13:31:44.040 STDERR tofu: │   with module.storage.mysql_database.antispam_db[0],
13:31:44.040 STDOUT tofu:       + id             = (known after apply)
13:31:44.040 STDERR tofu: │   on ../../storage/main.tf line 70, in resource "mysql_database" "antispam_db":
13:31:44.041 STDOUT tofu:       + secret_binary  = (sensitive value)
13:31:44.041 STDERR tofu: │   70: resource "mysql_database" "antispam_db" {
13:31:44.041 STDERR tofu: │ 
13:31:44.041 STDERR tofu: ╵
13:31:44.041 STDOUT tofu:       + secret_id      = "arn:aws:secretsmanager:us-east-1:000000000000:secret:rds!cluster-c937eb58-1f4b-4724-aa32-9555197fae3d-Txc5rL"
13:31:44.041 STDOUT tofu:       + secret_string  = (sensitive value)
13:31:44.048 STDOUT tofu:       + version_id     = (known after apply)
13:31:44.048 STDOUT tofu:       + version_stages = (known after apply)
13:31:44.049 STDOUT tofu:     }
13:31:44.049 STDOUT tofu:   # module.storage.aws_rds_cluster.log_rds_cluster will be updated in-place
13:31:44.049 STDOUT tofu:   ~ resource "aws_rds_cluster" "log_rds_cluster" {
13:31:44.049 STDOUT tofu:       ~ engine_version                        = "8.0.mysql_aurora.3.08.2" -> "8.0.mysql_aurora.3.05.2"
13:31:44.050 STDOUT tofu:         id                                    = "test-static-ct-cluster"
13:31:44.050 STDOUT tofu:         tags                                  = {}
13:31:44.050 STDOUT tofu:         # (44 unchanged attributes hidden)
13:31:44.050 STDOUT tofu:     }
13:31:44.050 STDOUT tofu:   # module.storage.aws_rds_cluster_instance.cluster_instances[0] will be updated in-place
13:31:44.051 STDOUT tofu:   ~ resource "aws_rds_cluster_instance" "cluster_instances" {
13:31:44.051 STDOUT tofu:       ~ engine_version                        = "8.0.mysql_aurora.3.08.2" -> "8.0.mysql_aurora.3.05.2"
13:31:44.052 STDOUT tofu:         id                                    = "test-static-ct-1"
13:31:44.052 STDOUT tofu:         tags                                  = {}
13:31:44.052 STDOUT tofu:         # (27 unchanged attributes hidden)
13:31:44.053 STDOUT tofu:     }
13:31:44.053 STDOUT tofu: Plan: 0 to add, 2 to change, 0 to destroy.
```