### PR TITLE
Add --bundle_compressed flag to allow Sunlight logs to be fsck'd

### DIFF
--- a/cmd/fsck/main.go
+++ b/cmd/fsck/main.go
@@ -278,8 +278,8 @@ func fetcherFromFlags() fetcher {
 
 	if logURL.Scheme == "file" {
 		return &client.FileFetcher{
-			Root:                    logURL.Path,
-			IsEntryBundleCompressed: *bundleCompressed,
+			Root:              logURL.Path,
+			DecompressBundles: *bundleCompressed,
 		}
 	}
 

--- a/cmd/fsck/main.go
+++ b/cmd/fsck/main.go
@@ -46,6 +46,7 @@ var (
 	origin        = flag.String("origin", "", "Origin of the log to check")
 	pubKey        = flag.String("public_key", "", "The log's public key in base64 encoded DER format")
 	userAgentInfo = flag.String("user_agent_info", "", "Optional string to append to the user agent (e.g. email address for Sunlight logs)")
+	bundleCompressed = flag.Bool("bundle_compressed", false, "Enable decompression of entry bundles, useful for Sunlight logs")
 )
 
 const (
@@ -276,7 +277,10 @@ func fetcherFromFlags() fetcher {
 	}
 
 	if logURL.Scheme == "file" {
-		return &client.FileFetcher{Root: logURL.Path}
+		return &client.FileFetcher{
+			Root:                    logURL.Path,
+			IsEntryBundleCompressed: *bundleCompressed,
+		}
 	}
 
 	hc := &http.Client{

--- a/internal/client/fetcher.go
+++ b/internal/client/fetcher.go
@@ -15,6 +15,8 @@
 package client
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/hex"
 	"fmt"
@@ -149,7 +151,23 @@ func (h HTTPFetcher) ReadIssuer(ctx context.Context, hash []byte) ([]byte, error
 
 // FileFetcher knows how to fetch log artifacts from a filesystem rooted at Root.
 type FileFetcher struct {
-	Root string
+	Root                    string
+	IsEntryBundleCompressed bool
+}
+
+// decompress decompresses gzip data if needed
+func (f FileFetcher) decompress(data []byte, compressed bool) ([]byte, error) {
+	if !compressed {
+		return data, nil
+	}
+
+	reader, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gzip reader: %v", err)
+	}
+	defer reader.Close()
+
+	return io.ReadAll(reader)
 }
 
 func (f FileFetcher) ReadCheckpoint(_ context.Context) ([]byte, error) {
@@ -164,7 +182,11 @@ func (f FileFetcher) ReadTile(ctx context.Context, l, i uint64, p uint8) ([]byte
 
 func (f FileFetcher) ReadEntryBundle(ctx context.Context, i uint64, p uint8) ([]byte, error) {
 	return PartialOrFullResource(ctx, p, func(ctx context.Context, p uint8) ([]byte, error) {
-		return os.ReadFile(path.Join(f.Root, ctEntriesPath(i, p)))
+		data, err := os.ReadFile(path.Join(f.Root, ctEntriesPath(i, p)))
+		if err != nil {
+			return nil, err
+		}
+		return f.decompress(data, f.IsEntryBundleCompressed)
 	})
 }
 


### PR DESCRIPTION
Companion to https://github.com/transparency-dev/tessera/pull/747 ✈️ - dependent on upstream library change!

This adds a flag -bundle_compressed that optionally informs fsck to decompress entrybundles when read from `file://` endpoints, notably Sunlight logs, which store them compressed on disk.

Before this change, fsck would not work on `--monitoring_url=file://` endpoints. Now, it works:

```
pim@summer:~/src/transparency-dev/tesseract$ go run ./cmd/fsck --monitoring_url=file:///home/pim/rennet2026h1/data/ -origin=rennet2026h1.log.ct.ipng.ch -public_key="MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEjjELwgGMea6d7YAOP1h1Q3z5IGFOFV/kmbT0qdRgMbhQCYZdDU/fObbHf7dPEGjlg/XbBCnmHJKJySK85tzC2w==" --compressed
I0826 15:00:29.178454 4087529 main.go:337] Using verifier string: rennet2026h1.log.ct.ipng.ch+0d83f616+BTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABI4xC8IBjHmune2ADj9YdUN8+SBhThVf5Jm09KnUYDG4UAmGXQ1P3zm2x3+3TxBo5YP12wQp5hySickivObcwts=
I0826 15:00:29.178495 4087529 main.go:112] Checking issuers CAS
I0826 15:00:29.178833 4087529 fsck.go:56] Fsck: checking log of size 444
I0826 15:00:29.189873 4087529 fsck.go:111] Successfully fsck'd log with size 444 and root QgXSyRRltEmRmG5bDCbeWohy1e+0g1jzCERVL3QkxHg= (4205d2c91465b44991986e5b0c26de5a8872d5efb48358f30844552f7424c478)
I0826 15:00:29.189910 4087529 main.go:82] OK
```

Should be merged after the tessera repo 747 is reviewed and merged.