### PR TITLE
Add witness policy support to TesseraCT/POSIX

### DIFF
--- a/cmd/tesseract/posix/README.md
+++ b/cmd/tesseract/posix/README.md
@@ -22,6 +22,25 @@ work too, `CephFS` may work, but `NFS` will almost certainly not.
 > Attempting to use a filesystem which does not provide POSIX filesystem
 > semantics is overwhelmingly likely to result in a broken log!
 
+
+## Witnessing
+
+> [!WARNING]
+> Witnessing support is experimental at the moment - there is work actively underway
+> in this space by the transparency community.
+> Correspondingly, the interaction with the configured witnesses is currently hard-coded
+> to fail-open in the event that insufficient witness cosignatures were acquired - i.e. 
+> checkpoints will continue to be published with or without witness cosignatures.
+
+This binary has support for interacting with [tlog-witness](https://c2sp.org/tlog-witness)
+compliant witnesses. To enable this, pass the path of a file containing a witness policy
+to the `--witness_policy_file` flag, and ensure that at least one file containing a
+note-compatible `Ed25519` signer known to the configured witness(es) is provided via the
+`--additional_signer` flag.
+
+The witness policy file is expected to contain a text-based description of the policy in
+the format described by https://git.glasklar.is/sigsum/core/sigsum-go/-/blob/main/doc/policy.md
+
 ## Codelab
 
 Generate an ECDSA key like so:

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -217,7 +217,10 @@ func newStorage(ctx context.Context, signer note.Signer) (*storage.CTStorage, er
 		if err != nil {
 			return nil, fmt.Errorf("failed to create witness group from policy: %v", err)
 		}
-		opts.WithWitnesses(wg, nil)
+
+		// Don't block if witnesses are unavailable.
+		wOpts := &tessera.WitnessOptions{FailOpen: true}
+		opts.WithWitnesses(wg, wOpts)
 	}
 
 	// TODO(phbnf): figure out the best way to thread the `shutdown` func NewAppends returns back out to main so we can cleanly close Tessera down

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -68,6 +68,7 @@ var (
 	rejectExtensions         = flag.String("reject_extension", "", "A list of X.509 extension OIDs, in dotted string form (e.g. '2.3.4.5') which, if present, should cause submissions to be rejected.")
 	acceptSHA1               = flag.Bool("accept_sha1_signing_algorithms", true, "If true, accept chains that use SHA-1 based signing algorithms. This flag will eventually be removed, and such algorithms will be rejected.")
 	enablePublicationAwaiter = flag.Bool("enable_publication_awaiter", true, "If true then the certificate is integrated into log before returning the response.")
+	witnessPolicyFile        = flag.String("witness_policy_file", "", "(Optional) Path to the file containing the witness policy in the format describe at https://git.glasklar.is/sigsum/core/sigsum-go/-/blob/main/doc/policy.md")
 
 	// Performance flags
 	httpDeadline              = flag.Duration("http_deadline", time.Second*10, "Deadline for HTTP requests.")
@@ -83,7 +84,6 @@ var (
 	clientHTTPMaxIdlePerHost  = flag.Int("client_http_max_idle_per_host", 10, "Maximum number of idle HTTP connections per host for outgoing requests.")
 
 	// Infrastructure setup flags
-	witnessPolicyFile = flag.String("witness_policy_file", "", "Path to the file containing the witness policy.")
 	storageDir  = flag.String("storage_dir", "", "Path to root of log storage.")
 	privKeyFile = flag.String("private_key", "", "Location of private key file. If unset, uses the contents of the LOG_PRIVATE_KEY environment variable.")
 )

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/rivo/tview v0.42.0
 	github.com/transparency-dev/formats v0.0.0-20250421220931-bb8ad4d07c26
 	github.com/transparency-dev/merkle v0.0.2
-	github.com/transparency-dev/tessera v1.0.0-rc2
+	github.com/transparency-dev/tessera v1.0.0-rc2.0.20250903142348-418b0268dcc5
 	go.opentelemetry.io/contrib/detectors/gcp v1.38.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0
 	go.opentelemetry.io/otel v1.38.0
@@ -55,6 +55,7 @@ require (
 	github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.5.3 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.29.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0 // indirect
+	github.com/avast/retry-go/v4 v4.6.1 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.1 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.6 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -650,6 +650,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/v10 v10.0.1/go.mod h1:YvhnlEePVnBS4+0z3fhPfUy7W1Ikj0Ih0vcRo/gZ1M0=
 github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4xei5aX110hRiI=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
+github.com/avast/retry-go/v4 v4.6.1 h1:VkOLRubHdisGrHnTu89g08aQEWEgRU7LVEop3GbIcMk=
+github.com/avast/retry-go/v4 v4.6.1/go.mod h1:V6oF8njAwxJ5gRo1Q7Cxab24xs5NCWZBeaHHBklR8mA=
 github.com/aws/aws-sdk-go-v2 v1.38.3 h1:B6cV4oxnMs45fql4yRH+/Po/YU+597zgWqvDpYMturk=
 github.com/aws/aws-sdk-go-v2 v1.38.3/go.mod h1:sDioUELIUO9Znk23YVmIk86/9DOpkbyyVb1i/gUNFXY=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.1 h1:i8p8P4diljCr60PpJp6qZXNlgX4m2yQFpYk+9ZT+J4E=
@@ -1001,8 +1003,12 @@ github.com/transparency-dev/formats v0.0.0-20250421220931-bb8ad4d07c26 h1:YTbkeF
 github.com/transparency-dev/formats v0.0.0-20250421220931-bb8ad4d07c26/go.mod h1:ODywn0gGarHMMdSkWT56ULoK8Hk71luOyRseKek9COw=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
+github.com/transparency-dev/tessera v0.2.0 h1:KZu0vt1nL6gSRJziDqnNlKMuzjeM+ZXANW2B4Oo/r9o=
+github.com/transparency-dev/tessera v0.2.0/go.mod h1:lJCDw1om4T8H73MWQaZ2XBg5Ca0mKozvZZrtd6j5UZw=
 github.com/transparency-dev/tessera v1.0.0-rc2 h1:BKtDWr0nhL9dG66cS4DyKU9lpZFbUZrpHGh+BpqakcU=
 github.com/transparency-dev/tessera v1.0.0-rc2/go.mod h1:aaLlvG/sEPMzT96iIF4hua6Z9pLzkfDtkbaUAR4IL8I=
+github.com/transparency-dev/tessera v1.0.0-rc2.0.20250903142348-418b0268dcc5 h1:HJABaLjaOX67BpklkcQ28qDCUuCzPOXM6r2Bm7nq1Gg=
+github.com/transparency-dev/tessera v1.0.0-rc2.0.20250903142348-418b0268dcc5/go.mod h1:aaLlvG/sEPMzT96iIF4hua6Z9pLzkfDtkbaUAR4IL8I=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
This PR adds optional witness policy support to the POSIX tesseract binary.

Adds the optional ability to:
- specify additional note signers via flag (needed to ensure we have an `ed25519` signature on the checkpoint for access to the witnesses)
- specify a witness policy file, and use the Tessera support for parsing the policy and interacting with the specified witnesses.

Towards #443 