### PR TITLE
Add read-header timeouts to HTTP servers

### DIFF
--- a/cmd/tesseract/aws/main.go
+++ b/cmd/tesseract/aws/main.go
@@ -144,7 +144,11 @@ eventually go away. See /internal/lax509/README.md for more information.`)
 	http.Handle("/", otelhttp.NewHandler(logHandler, "/"))
 
 	// Bring up the HTTP server and serve until we get a signal not to.
-	srv := http.Server{Addr: *httpEndpoint}
+	srv := http.Server{
+		Addr: *httpEndpoint,
+		// Set timeout for reading headers to avoid a slowloris attack.
+		ReadHeaderTimeout: 5 * time.Second,
+	}
 	shutdownWG := new(sync.WaitGroup)
 	shutdownWG.Add(1)
 	go awaitSignal(func() {

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -131,7 +131,11 @@ eventually go away. See /internal/lax509/README.md for more information.`)
 	http.Handle("/", otelhttp.NewHandler(logHandler, "/"))
 
 	// Bring up the HTTP server and serve until we get a signal not to.
-	srv := http.Server{Addr: *httpEndpoint}
+	srv := http.Server{
+		Addr: *httpEndpoint,
+		// Set timeout for reading headers to avoid a slowloris attack.
+		ReadHeaderTimeout: 5 * time.Second,
+	}
 	shutdownWG := new(sync.WaitGroup)
 	shutdownWG.Add(1)
 	go awaitSignal(func() {

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -124,7 +124,11 @@ eventually go away. See /internal/lax509/README.md for more information.`)
 	http.Handle("/", logHandler)
 
 	// Bring up the HTTP server and serve until we get a signal not to.
-	srv := http.Server{Addr: *httpEndpoint}
+	srv := http.Server{
+		Addr: *httpEndpoint,
+		// Set timeout for reading headers to avoid a slowloris attack.
+		ReadHeaderTimeout: 5 * time.Second,
+	}
 	shutdownWG := new(sync.WaitGroup)
 	shutdownWG.Add(1)
 	go awaitSignal(func() {


### PR DESCRIPTION
This PR addresses a potential DoS attack where a malicious client can open many connections, send requests, but not read headers. By default, there is no timeout set on `http.Server`, so these connections just pile up, consuming resources.

See https://en.wikipedia.org/wiki/Slowloris_(cyber_attack)

Similar issue reported against the Tessera conformance binaries in transparency-dev/tessera#766

