### PR TITLE
Support rate limiting of old submissions

### DIFF
--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -70,6 +71,7 @@ var (
 	acceptSHA1               = flag.Bool("accept_sha1_signing_algorithms", true, "If true, accept chains that use SHA-1 based signing algorithms. This flag will eventually be removed, and such algorithms will be rejected.")
 	enablePublicationAwaiter = flag.Bool("enable_publication_awaiter", true, "If true then the certificate is integrated into log before returning the response.")
 	witnessPolicyFile        = flag.String("witness_policy_file", "", "(Optional) Path to the file containing the witness policy in the format described at https://git.glasklar.is/sigsum/core/sigsum-go/-/blob/main/doc/policy.md")
+	limitOldCerts            = flag.String("limit_old_submissions", "", "Optionally rate limits submissions with old notBefore dates. Expects a value of with the format: \"<go duration>:<rate limit>\", e.g. \"30d:50\" would impose a limit of 50 certs/s on submissions whose notBefore date is >= 30days old.")
 
 	// Performance flags
 	httpDeadline              = flag.Duration("http_deadline", time.Second*10, "Deadline for HTTP requests.")
@@ -124,7 +126,10 @@ submitted by Chrome's Merge Delay Monitor Root for the time being, but will
 eventually go away. See /internal/lax509/README.md for more information.`)
 	}
 
-	logHandler, err := tesseract.NewLogHandler(ctx, *origin, signer, chainValidationConfig, newGCPStorage, *httpDeadline, *maskInternalErrors, *pathPrefix)
+	hOpts := tesseract.LogHandlerOpts{
+		OldSubmissionLimit: rateLimitFromFlags(),
+	}
+	logHandler, err := tesseract.NewLogHandler(ctx, *origin, signer, chainValidationConfig, newGCPStorage, *httpDeadline, *maskInternalErrors, *pathPrefix, hOpts)
 	if err != nil {
 		klog.Exitf("Can't initialize CT HTTP Server: %v", err)
 	}
@@ -307,4 +312,23 @@ func (t *timestampFlag) Set(w string) error {
 	}
 	t.t = &tt
 	return nil
+}
+
+func rateLimitFromFlags() *tesseract.OldSubmissionLimit {
+	if *limitOldCerts == "" {
+		return nil
+	}
+	bits := strings.Split(*limitOldCerts, ":")
+	if len(bits) != 2 {
+		klog.Exitf("Invalid format for --limit_old_submissions flag")
+	}
+	a, err := time.ParseDuration(bits[0])
+	if err != nil {
+		klog.Exitf("Invalid age passed to --limit_old_submissions flag %q: %v", bits[0], err)
+	}
+	l, err := strconv.ParseFloat(bits[1], 64)
+	if err != nil {
+		klog.Exitf("Invalid rate limit passed to --limit_old_submissions %q: %v", bits[1], err)
+	}
+	return &tesseract.OldSubmissionLimit{AgeThreshold: a, RateLimit: l}
 }

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -73,6 +74,7 @@ var (
 	acceptSHA1               = flag.Bool("accept_sha1_signing_algorithms", true, "If true, accept chains that use SHA-1 based signing algorithms. This flag will eventually be removed, and such algorithms will be rejected.")
 	enablePublicationAwaiter = flag.Bool("enable_publication_awaiter", true, "If true then the certificate is integrated into log before returning the response.")
 	witnessPolicyFile        = flag.String("witness_policy_file", "", "(Optional) Path to the file containing the witness policy in the format describe at https://git.glasklar.is/sigsum/core/sigsum-go/-/blob/main/doc/policy.md")
+	limitOldCerts            = flag.String("limit_old_submissions", "", "Optionally rate limits submissions with old notBefore dates. Expects a value of with the format: \"<go duration>:<rate limit>\", e.g. \"30d:50\" would impose a limit of 50 certs/s on submissions whose notBefore date is >= 30days old.")
 
 	// Performance flags
 	httpDeadline              = flag.Duration("http_deadline", time.Second*10, "Deadline for HTTP requests.")
@@ -117,7 +119,10 @@ submitted by Chrome's Merge Delay Monitor Root for the time being, but will
 eventually go away. See /internal/lax509/README.md for more information.`)
 	}
 
-	logHandler, err := tesseract.NewLogHandler(ctx, *origin, signer, chainValidationConfig, newStorage, *httpDeadline, *maskInternalErrors, *pathPrefix)
+	hOpts := tesseract.LogHandlerOpts{
+		OldSubmissionLimit: rateLimitFromFlags(),
+	}
+	logHandler, err := tesseract.NewLogHandler(ctx, *origin, signer, chainValidationConfig, newStorage, *httpDeadline, *maskInternalErrors, *pathPrefix, hOpts)
 	if err != nil {
 		klog.Exitf("Can't initialize CT HTTP Server: %v", err)
 	}
@@ -331,4 +336,23 @@ func (ms *multiStringFlag) String() string {
 func (ms *multiStringFlag) Set(w string) error {
 	*ms = append(*ms, w)
 	return nil
+}
+
+func rateLimitFromFlags() *tesseract.OldSubmissionLimit {
+	if *limitOldCerts == "" {
+		return nil
+	}
+	bits := strings.Split(*limitOldCerts, ":")
+	if len(bits) != 2 {
+		klog.Exitf("Invalid format for --limit_old_submissions flag")
+	}
+	a, err := time.ParseDuration(bits[0])
+	if err != nil {
+		klog.Exitf("Invalid age passed to --limit_old_submissions flag %q: %v", bits[0], err)
+	}
+	l, err := strconv.ParseFloat(bits[1], 64)
+	if err != nil {
+		klog.Exitf("Invalid rate limit passed to --limit_old_submissions %q: %v", bits[1], err)
+	}
+	return &tesseract.OldSubmissionLimit{AgeThreshold: a, RateLimit: l}
 }

--- a/internal/ct/otel.go
+++ b/internal/ct/otel.go
@@ -28,10 +28,11 @@ var (
 )
 
 var (
-	codeKey      = attribute.Key("http.response.status_code")
-	operationKey = attribute.Key("tesseract.operation")
-	originKey    = attribute.Key("tesseract.origin")
-	duplicateKey = attribute.Key("tesseract.duplicate")
+	codeKey            = attribute.Key("http.response.status_code")
+	operationKey       = attribute.Key("tesseract.operation")
+	originKey          = attribute.Key("tesseract.origin")
+	duplicateKey       = attribute.Key("tesseract.duplicate")
+	rateLimitReasonKey = attribute.Key("tesseract.rate_limit")
 )
 
 func mustCreate[T any](t T, err error) T {


### PR DESCRIPTION
This PR adds support for an (optional) simple rate limiter which can be used to cheaply throttle submissions of certs older than a given threshold.

Towards #538 