### PR TITLE
Wire up old submission rate limit

### DIFF
--- a/cmd/tesseract/README.md
+++ b/cmd/tesseract/README.md
@@ -54,6 +54,16 @@ means no upper bound on the accepted range. RFC3339 UTC format, e.g:
 signing algorithms. This flag is a temporary solution to allow chains submitted
 by Chrome's Merge Delay Monitor Root. It will eventually be removed and chains
 using such algorithms will be rejected.
+- `limit_old_submissions`: This optional flag can be set define a limit on how
+many "old" certificates and precertificates will be accepted per second.
+The flag value should be of the form `<age>:<limit>`, where `<limit>` is a
+per-second rate limit, and `<age>` defines how old a given submission's
+`notBefore` date must be for that submission to be subject to the rate limit.
+`<age>` must be formatted per Go's [time.ParseDuration](https://pkg.go.dev/time#ParseDuration),
+and `<limit>` is a positive real number.
+E.g. `28h=500` means that a rate-limit of 500 submissions/s will be applied to any
+certificate, or precertificate, whose `notBefore` date is at least 28 hours old
+at the time of submission.
 
 #### Adding to the log
 

--- a/deployment/live/gcp/static-ct-staging/logs/arche2025h1/terragrunt.hcl
+++ b/deployment/live/gcp/static-ct-staging/logs/arche2025h1/terragrunt.hcl
@@ -14,6 +14,7 @@ locals {
   trace_fraction                = 0.1
   create_internal_load_balancer = true
   public_bucket                 = true
+  limit_old_submissions         = "28h:150"
 }
 
 include "root" {

--- a/deployment/live/gcp/static-ct-staging/logs/arche2025h2/terragrunt.hcl
+++ b/deployment/live/gcp/static-ct-staging/logs/arche2025h2/terragrunt.hcl
@@ -15,6 +15,7 @@ locals {
   create_internal_load_balancer = true
   public_bucket                 = true
   machine_type                  = "n2-standard-8"
+  limit_old_submissions         = "28h:150"
 }
 
 include "root" {

--- a/deployment/live/gcp/static-ct-staging/logs/arche2026h1/terragrunt.hcl
+++ b/deployment/live/gcp/static-ct-staging/logs/arche2026h1/terragrunt.hcl
@@ -14,6 +14,7 @@ locals {
   trace_fraction                = 0.1
   create_internal_load_balancer = true
   public_bucket                 = true
+  limit_old_submissions         = "28h:150"
 }
 
 include "root" {

--- a/deployment/modules/gcp/gce/tesseract/main.tf
+++ b/deployment/modules/gcp/gce/tesseract/main.tf
@@ -39,7 +39,8 @@ module "gce_container_tesseract" {
       "--batch_max_size=${var.batch_max_size}",
       "--batch_max_age=${var.batch_max_age}",
       "--enable_publication_awaiter=${var.enable_publication_awaiter}",
-      "--accept_sha1_signing_algorithms=true"
+      "--accept_sha1_signing_algorithms=true",
+      "--limit_old_submissions=${var.limit_old_submissions}"
     ]
     tty : true # maybe remove this
   }

--- a/deployment/modules/gcp/gce/tesseract/variables.tf
+++ b/deployment/modules/gcp/gce/tesseract/variables.tf
@@ -99,3 +99,10 @@ variable "enable_publication_awaiter" {
   type        = bool
   default     = true
 }
+
+variable "limit_old_submissions" {
+  description = "Set to configure rate limiting for old submissions. See --limit_old_submissions flag for format."
+  type        = string
+  default     = ""
+}
+

--- a/deployment/modules/gcp/tesseract/gce/main.tf
+++ b/deployment/modules/gcp/tesseract/gce/main.tf
@@ -41,6 +41,7 @@ module "gce" {
   batch_max_age                  = var.batch_max_age
   batch_max_size                 = var.batch_max_size
   enable_publication_awaiter     = var.enable_publication_awaiter
+  limit_old_submissions          = var.limit_old_submissions
 
   depends_on = [
     module.secretmanager,

--- a/deployment/modules/gcp/tesseract/gce/variables.tf
+++ b/deployment/modules/gcp/tesseract/gce/variables.tf
@@ -98,3 +98,9 @@ variable "public_bucket" {
   type        = bool
   default     = false
 }
+
+variable "limit_old_submissions" {
+  description = "Set to configure rate limiting for old submissions. See --limit_old_submissions flag for format."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Configure the staging logs to apply the `limit_old_submissions` feature.

Fixes #570 