### PR TITLE
move dedupInFlight to a proper rate limiter

### DIFF
--- a/cmd/tesseract/README.md
+++ b/cmd/tesseract/README.md
@@ -119,7 +119,7 @@ This flag is on by default.
 
 #### Antispam
 
-The `pushback_max_antispam_lag`, `pushback_max_dedup_in_flight` and
+The `pushback_max_antispam_lag`, `rate_limit_dedup` and
 `inmemory_antispam_cache_size` flags control how [TesseraCT's Antispam feature](/docs/architecture.md#antispam)
 works, which itself is built on top of [Tessera's Antispam](https://github.com/transparency-dev/tessera?tab=readme-ov-file#antispam)
 capabilities. It is composed of three main steps:
@@ -146,14 +146,13 @@ calls faster, and provides optimistic coverage for entries submitted _very_
 recently and which have not yet been processed by the asynchronous process in
 `(1)`.
 
-The `pushback_max_dedup_in_flight` flag rate limits how many concurrent `add-*`
-requests identified as duplicates will be processed by the
-**synchronous** process in `(3)` wich fetches entries and extracts information
-required to build SCTs. When this value is exceeded, TesseraCT returns
-`429 -Too Many Requests` to subsequent **duplicate** `add-*` requests only.
-Non-duplicate `add-*` requests are not impacted, and can still be processed.
-This limits the amount of resources TesseraCT spends on servicing duplicate
-requests.
+The `rate_limit_dedup` flag rate limits how many concurrent `add-*` requests
+identified as duplicates will be processed by the **synchronous** process in
+`(3)` which fetches entries and extracts information required to build SCTs.
+When this value is exceeded, TesseraCT returns `429 -Too Many Requests` to
+subsequent **duplicate** `add-*` requests only. Non-duplicate `add-*` requests
+are not impacted, and can still be processed. This limits the amount of
+resources TesseraCT spends on servicing duplicate requests.
 
 ### Setup
 

--- a/cmd/tesseract/aws/main.go
+++ b/cmd/tesseract/aws/main.go
@@ -47,16 +47,16 @@ import (
 func init() {
 	flag.Var(&notAfterStart, "not_after_start", "Start of the range of acceptable NotAfter values, inclusive. Leaving this unset or empty implies no lower bound to the range. RFC3339 UTC format, e.g: 2024-01-02T15:04:05Z.")
 	flag.Var(&notAfterLimit, "not_after_limit", "Cut off point of notAfter dates - only notAfter dates strictly *before* notAfterLimit will be accepted. Leaving this unset or empty means no upper bound on the accepted range. RFC3339 UTC format, e.g: 2024-01-02T15:04:05Z.")
-	flag.Float64Var(&pushbackMaxDedupInFlight, "pushback_max_dedup_in_flight", 100, "Maximum number of number of in-flight duplicate add requests per second - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always pushed back.")
+	flag.Float64Var(&limitDedupInFlight, "limit_dedup_in_flight", 100, "Optionally rate limits the number of number of in-flight duplicate add requests - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always rate limited. When negative, no rate limits apply.")
 	// DEPRECATED: will be removed shortly
-	flag.Float64Var(&pushbackMaxDedupInFlight, "pushback_max_dedupe_in_flight", 100, "DEPRECATED: use pushback_max_dedup_in_flight. Maximum number of number of in-flight duplicate add requests - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always pushed back.")
+	flag.Float64Var(&limitDedupInFlight, "pushback_max_dedupe_in_flight", 100, "DEPRECATED: use pushback_max_dedup_in_flight. Maximum number of number of in-flight duplicate add requests - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always pushed back.")
 }
 
 // Global flags that affect all log instances.
 var (
-	notAfterStart            timestampFlag
-	notAfterLimit            timestampFlag
-	pushbackMaxDedupInFlight float64
+	notAfterStart      timestampFlag
+	notAfterLimit      timestampFlag
+	limitDedupInFlight float64
 
 	// Functionality flags
 	httpEndpoint             = flag.String("http_endpoint", "localhost:6962", "Endpoint for HTTP (host:port).")
@@ -141,7 +141,7 @@ eventually go away. See /internal/lax509/README.md for more information.`)
 
 	hOpts := tesseract.LogHandlerOpts{
 		OldSubmissionLimit: rateLimitFromFlags(),
-		DedupInFlightLimit: pushbackMaxDedupInFlight,
+		DedupInFlightLimit: limitDedupInFlight,
 	}
 	logHandler, err := tesseract.NewLogHandler(ctx, *origin, signer, chainValidationConfig, newAWSStorage, *httpDeadline, *maskInternalErrors, *pathPrefix, hOpts)
 	if err != nil {

--- a/cmd/tesseract/aws/main.go
+++ b/cmd/tesseract/aws/main.go
@@ -141,6 +141,7 @@ eventually go away. See /internal/lax509/README.md for more information.`)
 
 	hOpts := tesseract.LogHandlerOpts{
 		OldSubmissionLimit: rateLimitFromFlags(),
+		DedupInFlightLimit: pushbackMaxDedupInFlight,
 	}
 	logHandler, err := tesseract.NewLogHandler(ctx, *origin, signer, chainValidationConfig, newAWSStorage, *httpDeadline, *maskInternalErrors, *pathPrefix, hOpts)
 	if err != nil {
@@ -242,11 +243,10 @@ func newAWSStorage(ctx context.Context, signer note.Signer) (*storage.CTStorage,
 	}
 
 	sopts := storage.CTStorageOptions{
-		Appender:         appender,
-		Reader:           reader,
-		IssuerStorage:    issuerStorage,
-		EnableAwaiter:    *enablePublicationAwaiter,
-		MaxDedupInFlight: pushbackMaxDedupInFlight,
+		Appender:      appender,
+		Reader:        reader,
+		IssuerStorage: issuerStorage,
+		EnableAwaiter: *enablePublicationAwaiter,
 	}
 
 	return storage.NewCTStorage(ctx, &sopts)

--- a/cmd/tesseract/aws/main.go
+++ b/cmd/tesseract/aws/main.go
@@ -47,16 +47,16 @@ import (
 func init() {
 	flag.Var(&notAfterStart, "not_after_start", "Start of the range of acceptable NotAfter values, inclusive. Leaving this unset or empty implies no lower bound to the range. RFC3339 UTC format, e.g: 2024-01-02T15:04:05Z.")
 	flag.Var(&notAfterLimit, "not_after_limit", "Cut off point of notAfter dates - only notAfter dates strictly *before* notAfterLimit will be accepted. Leaving this unset or empty means no upper bound on the accepted range. RFC3339 UTC format, e.g: 2024-01-02T15:04:05Z.")
-	flag.Float64Var(&limitDedupInFlight, "limit_dedup_in_flight", 100, "Optionally rate limits the number of number of in-flight duplicate add requests - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always rate limited. When negative, no rate limits apply.")
+	flag.Float64Var(&dedupRL, "rate_limit_dedup", 100, "Rate limit for resolving duplicate submissions, in requests per second - i.e. duplicate requests for already integrated entries, which need to be fetched from the log storage by TesseraCT to extract their timestamp. When 0, all duplicate submissions are rejected. When negative, no rate limit is applied.")
 	// DEPRECATED: will be removed shortly
-	flag.Float64Var(&limitDedupInFlight, "pushback_max_dedupe_in_flight", 100, "DEPRECATED: use pushback_max_dedup_in_flight. Maximum number of number of in-flight duplicate add requests - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always pushed back.")
+	flag.Float64Var(&dedupRL, "pushback_max_dedupe_in_flight", 100, "DEPRECATED: use rate_limit_dedup. Maximum number of number of in-flight duplicate add requests - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always pushed back.")
 }
 
 // Global flags that affect all log instances.
 var (
-	notAfterStart      timestampFlag
-	notAfterLimit      timestampFlag
-	limitDedupInFlight float64
+	notAfterStart timestampFlag
+	notAfterLimit timestampFlag
+	dedupRL       float64
 
 	// Functionality flags
 	httpEndpoint             = flag.String("http_endpoint", "localhost:6962", "Endpoint for HTTP (host:port).")
@@ -141,7 +141,7 @@ eventually go away. See /internal/lax509/README.md for more information.`)
 
 	hOpts := tesseract.LogHandlerOpts{
 		OldSubmissionLimit: rateLimitFromFlags(),
-		DedupInFlightLimit: limitDedupInFlight,
+		DedupRL:            dedupRL,
 	}
 	logHandler, err := tesseract.NewLogHandler(ctx, *origin, signer, chainValidationConfig, newAWSStorage, *httpDeadline, *maskInternalErrors, *pathPrefix, hOpts)
 	if err != nil {

--- a/cmd/tesseract/aws/main.go
+++ b/cmd/tesseract/aws/main.go
@@ -47,16 +47,16 @@ import (
 func init() {
 	flag.Var(&notAfterStart, "not_after_start", "Start of the range of acceptable NotAfter values, inclusive. Leaving this unset or empty implies no lower bound to the range. RFC3339 UTC format, e.g: 2024-01-02T15:04:05Z.")
 	flag.Var(&notAfterLimit, "not_after_limit", "Cut off point of notAfter dates - only notAfter dates strictly *before* notAfterLimit will be accepted. Leaving this unset or empty means no upper bound on the accepted range. RFC3339 UTC format, e.g: 2024-01-02T15:04:05Z.")
-	flag.UintVar(&pushbackMaxDedupInFlight, "pushback_max_dedup_in_flight", 100, "Maximum number of number of in-flight duplicate add requests - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always pushed back.")
+	flag.Float64Var(&pushbackMaxDedupInFlight, "pushback_max_dedup_in_flight", 100, "Maximum number of number of in-flight duplicate add requests per second - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always pushed back.")
 	// DEPRECATED: will be removed shortly
-	flag.UintVar(&pushbackMaxDedupInFlight, "pushback_max_dedupe_in_flight", 100, "DEPRECATED: use pushback_max_dedup_in_flight. Maximum number of number of in-flight duplicate add requests - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always pushed back.")
+	flag.Float64Var(&pushbackMaxDedupInFlight, "pushback_max_dedupe_in_flight", 100, "DEPRECATED: use pushback_max_dedup_in_flight. Maximum number of number of in-flight duplicate add requests - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always pushed back.")
 }
 
 // Global flags that affect all log instances.
 var (
 	notAfterStart            timestampFlag
 	notAfterLimit            timestampFlag
-	pushbackMaxDedupInFlight uint
+	pushbackMaxDedupInFlight float64
 
 	// Functionality flags
 	httpEndpoint             = flag.String("http_endpoint", "localhost:6962", "Endpoint for HTTP (host:port).")

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -46,9 +46,9 @@ func init() {
 	flag.Var(&notAfterStart, "not_after_start", "Start of the range of acceptable NotAfter values, inclusive. Leaving this unset or empty implies no lower bound to the range. RFC3339 UTC format, e.g: 2024-01-02T15:04:05Z.")
 	flag.Var(&notAfterLimit, "not_after_limit", "Cut off point of notAfter dates - only notAfter dates strictly *before* notAfterLimit will be accepted. Leaving this unset or empty means no upper bound on the accepted range. RFC3339 UTC format, e.g: 2024-01-02T15:04:05Z.")
 	flag.Var(&additionalSigners, "additional_signer_private_key_secret_name", "Private key secret name for additional Ed25519 checkpoint signatures, may be supplied multiple times. Format: projects/{projectId}/secrets/{secretName}/versions/{secretVersion}.")
-	flag.UintVar(&pushbackMaxDedupInFlight, "pushback_max_dedup_in_flight", 100, "Maximum number of number of in-flight duplicate add requests - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always pushed back.")
+	flag.Float64Var(&pushbackMaxDedupInFlight, "pushback_max_dedup_in_flight", 100, "Maximum number of number of in-flight duplicate add requests per second - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always pushed back.")
 	// DEPRECATED: will be removed shortly
-	flag.UintVar(&pushbackMaxDedupInFlight, "pushback_max_dedupe_in_flight", 100, "DEPRECATED: use pushback_max_dedup_in_flight. Maximum number of number of in-flight duplicate add requests - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always pushed back.")
+	flag.Float64Var(&pushbackMaxDedupInFlight, "pushback_max_dedupe_in_flight", 100, "DEPRECATED: use pushback_max_dedup_in_flight. Maximum number of number of in-flight duplicate add requests - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always pushed back.")
 }
 
 // Global flags that affect all log instances.
@@ -56,7 +56,7 @@ var (
 	notAfterStart            timestampFlag
 	notAfterLimit            timestampFlag
 	additionalSigners        multiStringFlag
-	pushbackMaxDedupInFlight uint
+	pushbackMaxDedupInFlight float64
 
 	// Functionality flags
 	httpEndpoint             = flag.String("http_endpoint", "localhost:6962", "Endpoint for HTTP (host:port).")

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -128,6 +128,7 @@ eventually go away. See /internal/lax509/README.md for more information.`)
 
 	hOpts := tesseract.LogHandlerOpts{
 		OldSubmissionLimit: rateLimitFromFlags(),
+		DedupInFlightLimit: pushbackMaxDedupInFlight,
 	}
 	logHandler, err := tesseract.NewLogHandler(ctx, *origin, signer, chainValidationConfig, newGCPStorage, *httpDeadline, *maskInternalErrors, *pathPrefix, hOpts)
 	if err != nil {
@@ -279,11 +280,10 @@ func newGCPStorage(ctx context.Context, signer note.Signer) (*storage.CTStorage,
 	}
 
 	sopts := storage.CTStorageOptions{
-		Appender:         appender,
-		Reader:           reader,
-		IssuerStorage:    issuerStorage,
-		EnableAwaiter:    *enablePublicationAwaiter,
-		MaxDedupInFlight: pushbackMaxDedupInFlight,
+		Appender:      appender,
+		Reader:        reader,
+		IssuerStorage: issuerStorage,
+		EnableAwaiter: *enablePublicationAwaiter,
 	}
 
 	return storage.NewCTStorage(ctx, &sopts)

--- a/cmd/tesseract/gcp/main.go
+++ b/cmd/tesseract/gcp/main.go
@@ -46,17 +46,17 @@ func init() {
 	flag.Var(&notAfterStart, "not_after_start", "Start of the range of acceptable NotAfter values, inclusive. Leaving this unset or empty implies no lower bound to the range. RFC3339 UTC format, e.g: 2024-01-02T15:04:05Z.")
 	flag.Var(&notAfterLimit, "not_after_limit", "Cut off point of notAfter dates - only notAfter dates strictly *before* notAfterLimit will be accepted. Leaving this unset or empty means no upper bound on the accepted range. RFC3339 UTC format, e.g: 2024-01-02T15:04:05Z.")
 	flag.Var(&additionalSigners, "additional_signer_private_key_secret_name", "Private key secret name for additional Ed25519 checkpoint signatures, may be supplied multiple times. Format: projects/{projectId}/secrets/{secretName}/versions/{secretVersion}.")
-	flag.Float64Var(&pushbackMaxDedupInFlight, "pushback_max_dedup_in_flight", 100, "Maximum number of number of in-flight duplicate add requests per second - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always pushed back.")
+	flag.Float64Var(&limitDedupInFlight, "limit_dedup_in_flight", 100, "Optionally rate limits the number of number of in-flight duplicate add requests - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always rate limited. When negative, no rate limits apply.")
 	// DEPRECATED: will be removed shortly
-	flag.Float64Var(&pushbackMaxDedupInFlight, "pushback_max_dedupe_in_flight", 100, "DEPRECATED: use pushback_max_dedup_in_flight. Maximum number of number of in-flight duplicate add requests - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always pushed back.")
+	flag.Float64Var(&limitDedupInFlight, "pushback_max_dedupe_in_flight", 100, "DEPRECATED: use limit_dedup_in_flight. Maximum number of number of in-flight duplicate add requests - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always pushed back.")
 }
 
 // Global flags that affect all log instances.
 var (
-	notAfterStart            timestampFlag
-	notAfterLimit            timestampFlag
-	additionalSigners        multiStringFlag
-	pushbackMaxDedupInFlight float64
+	notAfterStart      timestampFlag
+	notAfterLimit      timestampFlag
+	additionalSigners  multiStringFlag
+	limitDedupInFlight float64
 
 	// Functionality flags
 	httpEndpoint             = flag.String("http_endpoint", "localhost:6962", "Endpoint for HTTP (host:port).")
@@ -128,7 +128,7 @@ eventually go away. See /internal/lax509/README.md for more information.`)
 
 	hOpts := tesseract.LogHandlerOpts{
 		OldSubmissionLimit: rateLimitFromFlags(),
-		DedupInFlightLimit: pushbackMaxDedupInFlight,
+		DedupInFlightLimit: limitDedupInFlight,
 	}
 	logHandler, err := tesseract.NewLogHandler(ctx, *origin, signer, chainValidationConfig, newGCPStorage, *httpDeadline, *maskInternalErrors, *pathPrefix, hOpts)
 	if err != nil {

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -49,9 +49,9 @@ func init() {
 	flag.Var(&notAfterStart, "not_after_start", "Start of the range of acceptable NotAfter values, inclusive. Leaving this unset implies no lower bound to the range. RFC3339 UTC format, e.g: 2024-01-02T15:04:05Z.")
 	flag.Var(&notAfterLimit, "not_after_limit", "Cut off point of notAfter dates - only notAfter dates strictly *before* notAfterLimit will be accepted. Leaving this unset means no upper bound on the accepted range. RFC3339 UTC format, e.g: 2024-01-02T15:04:05Z.")
 	flag.Var(&additionalSigners, "additional_signer", "Path to a file containing an additional note Signer formatted keys for checkpoints. May be specified multiple times.")
-	flag.UintVar(&pushbackMaxDedupInFlight, "pushback_max_dedup_in_flight", 100, "Maximum number of number of in-flight duplicate add requests - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always pushed back.")
+	flag.Float64Var(&pushbackMaxDedupInFlight, "pushback_max_dedup_in_flight", 100, "Maximum number of number of in-flight duplicate add requests per second - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always pushed back.")
 	// DEPRECATED: will be removed shortly
-	flag.UintVar(&pushbackMaxDedupInFlight, "pushback_max_dedupe_in_flight", 100, "DEPRECATED: use pushback_max_dedup_in_flight. Maximum number of number of in-flight duplicate add requests - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always pushed back.")
+	flag.Float64Var(&pushbackMaxDedupInFlight, "pushback_max_dedupe_in_flight", 100, "DEPRECATED: use pushback_max_dedup_in_flight. Maximum number of number of in-flight duplicate add requests - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always pushed back.")
 }
 
 // Global flags that affect all log instances.
@@ -59,7 +59,7 @@ var (
 	notAfterStart            timestampFlag
 	notAfterLimit            timestampFlag
 	additionalSigners        multiStringFlag
-	pushbackMaxDedupInFlight uint
+	pushbackMaxDedupInFlight float64
 
 	// Functionality flags
 	httpEndpoint             = flag.String("http_endpoint", "localhost:6962", "Endpoint for HTTP (host:port).")
@@ -121,6 +121,7 @@ eventually go away. See /internal/lax509/README.md for more information.`)
 
 	hOpts := tesseract.LogHandlerOpts{
 		OldSubmissionLimit: rateLimitFromFlags(),
+		DedupInFlightLimit: pushbackMaxDedupInFlight,
 	}
 	logHandler, err := tesseract.NewLogHandler(ctx, *origin, signer, chainValidationConfig, newStorage, *httpDeadline, *maskInternalErrors, *pathPrefix, hOpts)
 	if err != nil {
@@ -258,11 +259,10 @@ func newStorage(ctx context.Context, signer note.Signer) (st *storage.CTStorage,
 	}
 
 	sopts := storage.CTStorageOptions{
-		Appender:         appender,
-		Reader:           reader,
-		IssuerStorage:    issuerStorage,
-		EnableAwaiter:    *enablePublicationAwaiter,
-		MaxDedupInFlight: pushbackMaxDedupInFlight,
+		Appender:      appender,
+		Reader:        reader,
+		IssuerStorage: issuerStorage,
+		EnableAwaiter: *enablePublicationAwaiter,
 	}
 	return storage.NewCTStorage(ctx, &sopts)
 }

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -49,17 +49,17 @@ func init() {
 	flag.Var(&notAfterStart, "not_after_start", "Start of the range of acceptable NotAfter values, inclusive. Leaving this unset implies no lower bound to the range. RFC3339 UTC format, e.g: 2024-01-02T15:04:05Z.")
 	flag.Var(&notAfterLimit, "not_after_limit", "Cut off point of notAfter dates - only notAfter dates strictly *before* notAfterLimit will be accepted. Leaving this unset means no upper bound on the accepted range. RFC3339 UTC format, e.g: 2024-01-02T15:04:05Z.")
 	flag.Var(&additionalSigners, "additional_signer", "Path to a file containing an additional note Signer formatted keys for checkpoints. May be specified multiple times.")
-	flag.Float64Var(&pushbackMaxDedupInFlight, "pushback_max_dedup_in_flight", 100, "Maximum number of number of in-flight duplicate add requests per second - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always pushed back.")
+	flag.Float64Var(&dedupRL, "rate_limit_dedup", 100, "Rate limit for resolving duplicate submissions, in requests per second - i.e. duplicate requests for already integrated entries, which need to be fetched from the log storage by TesseraCT to extract their timestamp. When 0, all duplicate submissions are rejected. When negative, no rate limit is applied.")
 	// DEPRECATED: will be removed shortly
-	flag.Float64Var(&pushbackMaxDedupInFlight, "pushback_max_dedupe_in_flight", 100, "DEPRECATED: use pushback_max_dedup_in_flight. Maximum number of number of in-flight duplicate add requests - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always pushed back.")
+	flag.Float64Var(&dedupRL, "pushback_max_dedupe_in_flight", 100, "DEPRECATED: use rate_limit_dedup. Maximum number of number of in-flight duplicate add requests - i.e. the number of requests matching entries that have already been integrated, but need to be fetched by the client to retrieve their timestamp. When 0, duplicate entries are always pushed back.")
 }
 
 // Global flags that affect all log instances.
 var (
-	notAfterStart            timestampFlag
-	notAfterLimit            timestampFlag
-	additionalSigners        multiStringFlag
-	pushbackMaxDedupInFlight float64
+	notAfterStart     timestampFlag
+	notAfterLimit     timestampFlag
+	additionalSigners multiStringFlag
+	dedupRL           float64
 
 	// Functionality flags
 	httpEndpoint             = flag.String("http_endpoint", "localhost:6962", "Endpoint for HTTP (host:port).")

--- a/cmd/tesseract/posix/main.go
+++ b/cmd/tesseract/posix/main.go
@@ -121,7 +121,7 @@ eventually go away. See /internal/lax509/README.md for more information.`)
 
 	hOpts := tesseract.LogHandlerOpts{
 		OldSubmissionLimit: rateLimitFromFlags(),
-		DedupInFlightLimit: pushbackMaxDedupInFlight,
+		DedupRL:            dedupRL,
 	}
 	logHandler, err := tesseract.NewLogHandler(ctx, *origin, signer, chainValidationConfig, newStorage, *httpDeadline, *maskInternalErrors, *pathPrefix, hOpts)
 	if err != nil {

--- a/ctlog.go
+++ b/ctlog.go
@@ -160,9 +160,11 @@ func NewLogHandler(ctx context.Context, origin string, signer crypto.Signer, cfg
 		TimeSource:         sysTimeSource,
 		PathPrefix:         pathPrefix,
 	}
-	ctOpts.RateLimits.DedupInFlight(opts.DedupInFlightLimit)
 	if opts.OldSubmissionLimit != nil {
 		ctOpts.RateLimits.OldSubmission(opts.OldSubmissionLimit.AgeThreshold, opts.OldSubmissionLimit.RateLimit)
+	}
+	if opts.DedupInFlightLimit >= 0 {
+		ctOpts.RateLimits.DedupInFlight(opts.DedupInFlightLimit)
 	}
 
 	handlers := ct.NewPathHandlers(ctx, ctOpts, log)

--- a/ctlog.go
+++ b/ctlog.go
@@ -160,6 +160,7 @@ func NewLogHandler(ctx context.Context, origin string, signer crypto.Signer, cfg
 		TimeSource:         sysTimeSource,
 		PathPrefix:         pathPrefix,
 	}
+	ctOpts.RateLimits.DedupInFlight(opts.DedupInFlightLimit)
 	if opts.OldSubmissionLimit != nil {
 		ctOpts.RateLimits.OldSubmission(opts.OldSubmissionLimit.AgeThreshold, opts.OldSubmissionLimit.RateLimit)
 	}

--- a/ctlog.go
+++ b/ctlog.go
@@ -131,6 +131,7 @@ type OldSubmissionLimit struct {
 
 type LogHandlerOpts struct {
 	OldSubmissionLimit *OldSubmissionLimit
+	DedupInFlightLimit float64
 }
 
 // NewLogHandler creates a Tessera based CT log pluged into HTTP handlers.

--- a/ctlog.go
+++ b/ctlog.go
@@ -131,7 +131,7 @@ type OldSubmissionLimit struct {
 
 type LogHandlerOpts struct {
 	OldSubmissionLimit *OldSubmissionLimit
-	DedupInFlightLimit float64
+	DedupRL            float64
 }
 
 // NewLogHandler creates a Tessera based CT log pluged into HTTP handlers.
@@ -163,8 +163,8 @@ func NewLogHandler(ctx context.Context, origin string, signer crypto.Signer, cfg
 	if opts.OldSubmissionLimit != nil {
 		ctOpts.RateLimits.OldSubmission(opts.OldSubmissionLimit.AgeThreshold, opts.OldSubmissionLimit.RateLimit)
 	}
-	if opts.DedupInFlightLimit >= 0 {
-		ctOpts.RateLimits.DedupInFlight(opts.DedupInFlightLimit)
+	if opts.DedupRL >= 0 {
+		ctOpts.RateLimits.Dedup(opts.DedupRL)
 	}
 
 	handlers := ct.NewPathHandlers(ctx, ctOpts, log)

--- a/deployment/modules/gcp/gce/tesseract/main.tf
+++ b/deployment/modules/gcp/gce/tesseract/main.tf
@@ -40,7 +40,8 @@ module "gce_container_tesseract" {
       "--batch_max_age=${var.batch_max_age}",
       "--enable_publication_awaiter=${var.enable_publication_awaiter}",
       "--accept_sha1_signing_algorithms=true",
-      "--limit_old_submissions=${var.limit_old_submissions}"
+      "--limit_old_submissions=${var.limit_old_submissions}",
+      "--rate_limit_dedup=${var.rate_limit_dedup}"
     ]
     tty : true # maybe remove this
   }

--- a/deployment/modules/gcp/gce/tesseract/variables.tf
+++ b/deployment/modules/gcp/gce/tesseract/variables.tf
@@ -106,3 +106,8 @@ variable "limit_old_submissions" {
   default     = ""
 }
 
+variable "rate_limit_dedup" {
+  description = "Set to rate limit duplicate submissions per second."
+  type        = number
+  default     = -1 
+}

--- a/deployment/modules/gcp/tesseract/gce/main.tf
+++ b/deployment/modules/gcp/tesseract/gce/main.tf
@@ -42,6 +42,7 @@ module "gce" {
   batch_max_size                 = var.batch_max_size
   enable_publication_awaiter     = var.enable_publication_awaiter
   limit_old_submissions          = var.limit_old_submissions
+  rate_limit_dedup               = var.rate_limit_dedup
 
   depends_on = [
     module.secretmanager,

--- a/deployment/modules/gcp/tesseract/gce/variables.tf
+++ b/deployment/modules/gcp/tesseract/gce/variables.tf
@@ -104,3 +104,9 @@ variable "limit_old_submissions" {
   type        = string
   default     = ""
 }
+
+variable "rate_limit_dedup" {
+  description = "Set to rate limit duplicate submissions per second."
+  type        = number
+  default     = -1 
+}

--- a/internal/ct/ctlog.go
+++ b/internal/ct/ctlog.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/transparency-dev/tessera"
 	"github.com/transparency-dev/tessera/ctonly"
 	"github.com/transparency-dev/tesseract/internal/types/rfc6962"
 	"github.com/transparency-dev/tesseract/storage"
@@ -34,7 +35,9 @@ type signSCT func(leaf *rfc6962.MerkleTreeLeaf) (*rfc6962.SignedCertificateTimes
 // Storage provides functions to store certificates in a static-ct-api log.
 type Storage interface {
 	// Add assigns an index to the provided Entry, stages the entry for integration, and returns a future for the assigned index.
-	Add(context.Context, *ctonly.Entry) (idx uint64, timestamp uint64, err error)
+	Add(context.Context, *ctonly.Entry) (tessera.IndexFuture, error)
+	// DedupFuture fetches a duplicate tessera ctlog entry from the log and extracts its timestamp.
+	DedupFuture(context.Context, tessera.IndexFuture) (uint64, error)
 	// AddIssuerChain stores every the chain certificate in a content-addressable store under their sha256 hash.
 	AddIssuerChain(context.Context, []*x509.Certificate) error
 }

--- a/internal/ct/handlers_test.go
+++ b/internal/ct/handlers_test.go
@@ -800,7 +800,7 @@ func TestMaxDedupInFlight(t *testing.T) {
 	for _, test := range tests {
 		log, _ := setupTestLog(t)
 		hhOpts := hOpts()
-		hhOpts.RateLimits.DedupInFlight(test.maxRate)
+		hhOpts.RateLimits.Dedup(test.maxRate)
 		server := setupTestServer(t, log, path.Join(prefix, rfc6962.AddChainPath), hhOpts)
 		defer server.Close()
 

--- a/internal/ct/handlers_test.go
+++ b/internal/ct/handlers_test.go
@@ -64,19 +64,20 @@ var (
 	origin = "example.com"
 	prefix = "/" + origin
 
-	// Default handler options for tests
-	hOpts = HandlerOptions{
+	// POSIX subdirectory
+	logDir = "log"
+)
+
+func hOpts() *HandlerOptions {
+	return &HandlerOptions{
 		Deadline:           time.Millisecond * 2000,
 		RequestLog:         &DefaultRequestLog{},
 		MaskInternalErrors: false,
 		TimeSource:         timeSource,
 		PathPrefix:         prefix,
 	}
-	defaultMaxDedupInFlight = 10.0
 
-	// POSIX subdirectory
-	logDir = "log"
-)
+}
 
 type fixedTimeSource struct {
 	fakeTime time.Time
@@ -105,7 +106,7 @@ func (f *fixedTimeSource) Add1m() {
 // setupTestLog creates a test TesseraCT log using a POSIX backend.
 //
 // It returns the log and the path to the storage directory.
-func setupTestLog(t *testing.T, maxDedupInFlight float64) (*log, string) {
+func setupTestLog(t *testing.T) (*log, string) {
 	t.Helper()
 	storageDir := t.TempDir()
 
@@ -125,7 +126,7 @@ func setupTestLog(t *testing.T, maxDedupInFlight float64) (*log, string) {
 		rejectUnexpired: false,
 	}
 
-	log, err := NewLog(t.Context(), origin, sctSigner.signer, cv, newPOSIXStorageFunc(t, storageDir, maxDedupInFlight), timeSource)
+	log, err := NewLog(t.Context(), origin, sctSigner.signer, cv, newPOSIXStorageFunc(t, storageDir), timeSource)
 	if err != nil {
 		t.Fatalf("newLog(): %v", err)
 	}
@@ -133,19 +134,11 @@ func setupTestLog(t *testing.T, maxDedupInFlight float64) (*log, string) {
 	return log, storageDir
 }
 
-// setupDefaultTestLog creates a test TesseraCT log using a POSIX backend and default parameters.
-//
-// It returns the log and the path to the storage directory.
-func setupDefaultTestLog(t *testing.T) (*log, string) {
-	t.Helper()
-	return setupTestLog(t, defaultMaxDedupInFlight)
-}
-
 // setupTestServer creates a test TesseraCT server with a single endpoint at path.
-func setupTestServer(t *testing.T, log *log, path string) *httptest.Server {
+func setupTestServer(t *testing.T, log *log, path string, hOpts *HandlerOptions) *httptest.Server {
 	t.Helper()
 
-	handlers := NewPathHandlers(t.Context(), &hOpts, log)
+	handlers := NewPathHandlers(t.Context(), hOpts, log)
 	handler, ok := handlers[path]
 	if !ok {
 		t.Fatalf("Handler not found: %s", path)
@@ -160,7 +153,7 @@ func setupTestServer(t *testing.T, log *log, path string) *httptest.Server {
 //   - a POSIX issuer storage system
 //
 // It also prepares directories to host the log and the deduplication database.
-func newPOSIXStorageFunc(t *testing.T, root string, maxDedupInFlight float64) storage.CreateStorage {
+func newPOSIXStorageFunc(t *testing.T, root string) storage.CreateStorage {
 	t.Helper()
 
 	return func(ctx context.Context, signer note.Signer) (*storage.CTStorage, error) {
@@ -195,11 +188,10 @@ func newPOSIXStorageFunc(t *testing.T, root string, maxDedupInFlight float64) st
 		}
 
 		sopts := storage.CTStorageOptions{
-			Appender:         appender,
-			Reader:           reader,
-			IssuerStorage:    issuerStorage,
-			EnableAwaiter:    false,
-			MaxDedupInFlight: maxDedupInFlight,
+			Appender:      appender,
+			Reader:        reader,
+			IssuerStorage: issuerStorage,
+			EnableAwaiter: false,
 		}
 		s, err := storage.NewCTStorage(t.Context(), &sopts)
 		if err != nil {
@@ -240,8 +232,8 @@ func postHandlers(t *testing.T, handlers pathHandlers) pathHandlers {
 }
 
 func TestPostHandlersRejectGet(t *testing.T) {
-	log, _ := setupDefaultTestLog(t)
-	handlers := NewPathHandlers(t.Context(), &hOpts, log)
+	log, _ := setupTestLog(t)
+	handlers := NewPathHandlers(t.Context(), hOpts(), log)
 
 	// Anything in the post handler list should reject GET
 	for path, handler := range postHandlers(t, handlers) {
@@ -261,8 +253,8 @@ func TestPostHandlersRejectGet(t *testing.T) {
 }
 
 func TestGetHandlersRejectPost(t *testing.T) {
-	log, _ := setupDefaultTestLog(t)
-	handlers := NewPathHandlers(t.Context(), &hOpts, log)
+	log, _ := setupTestLog(t)
+	handlers := NewPathHandlers(t.Context(), hOpts(), log)
 
 	// Anything in the get handler list should reject POST.
 	for path, handler := range getHandlers(t, handlers) {
@@ -294,8 +286,8 @@ func TestPostHandlersFailure(t *testing.T) {
 		{"wrong-chain", strings.NewReader(`{ "chain": [ "test" ] }`), http.StatusBadRequest},
 	}
 
-	log, _ := setupDefaultTestLog(t)
-	handlers := NewPathHandlers(t.Context(), &hOpts, log)
+	log, _ := setupTestLog(t)
+	handlers := NewPathHandlers(t.Context(), hOpts(), log)
 
 	for path, handler := range postHandlers(t, handlers) {
 		t.Run(path, func(t *testing.T) {
@@ -316,7 +308,7 @@ func TestPostHandlersFailure(t *testing.T) {
 }
 
 func TestNewPathHandlers(t *testing.T) {
-	log, _ := setupDefaultTestLog(t)
+	log, _ := setupTestLog(t)
 	t.Run("Handlers", func(t *testing.T) {
 		handlers := NewPathHandlers(t.Context(), &HandlerOptions{PathPrefix: prefix}, log)
 		// Check each entrypoint has a handler
@@ -367,8 +359,8 @@ func mustParseChain(t *testing.T, isPrecert bool, pemChain []string, root *x509.
 }
 
 func TestGetRoots(t *testing.T) {
-	log, _ := setupDefaultTestLog(t)
-	server := setupTestServer(t, log, path.Join(prefix, rfc6962.GetRootsPath))
+	log, _ := setupTestLog(t)
+	server := setupTestServer(t, log, path.Join(prefix, rfc6962.GetRootsPath), hOpts())
 	defer server.Close()
 
 	resp, err := http.Get(server.URL + path.Join(prefix, rfc6962.GetRootsPath))
@@ -457,8 +449,8 @@ func TestAddChainWhitespace(t *testing.T) {
 		},
 	}
 
-	log, _ := setupDefaultTestLog(t)
-	server := setupTestServer(t, log, path.Join(prefix, rfc6962.AddChainPath))
+	log, _ := setupTestLog(t)
+	server := setupTestServer(t, log, path.Join(prefix, rfc6962.AddChainPath), hOpts())
 	defer server.Close()
 
 	for _, test := range tests {
@@ -527,8 +519,8 @@ func TestAddChain(t *testing.T) {
 		},
 	}
 
-	log, dir := setupDefaultTestLog(t)
-	server := setupTestServer(t, log, path.Join(prefix, rfc6962.AddChainPath))
+	log, dir := setupTestLog(t)
+	server := setupTestServer(t, log, path.Join(prefix, rfc6962.AddChainPath), hOpts())
 	defer server.Close()
 	defer timeSource.Reset()
 
@@ -674,8 +666,8 @@ func TestAddPreChain(t *testing.T) {
 		},
 	}
 
-	log, dir := setupDefaultTestLog(t)
-	server := setupTestServer(t, log, path.Join(prefix, rfc6962.AddPreChainPath))
+	log, dir := setupTestLog(t)
+	server := setupTestServer(t, log, path.Join(prefix, rfc6962.AddPreChainPath), hOpts())
 	defer server.Close()
 	defer timeSource.Reset()
 
@@ -806,8 +798,10 @@ func TestMaxDedupInFlight(t *testing.T) {
 	defer timeSource.Reset()
 
 	for _, test := range tests {
-		log, _ := setupTestLog(t, test.maxRate)
-		server := setupTestServer(t, log, path.Join(prefix, rfc6962.AddChainPath))
+		log, _ := setupTestLog(t)
+		hhOpts := hOpts()
+		hhOpts.RateLimits.DedupInFlight(test.maxRate)
+		server := setupTestServer(t, log, path.Join(prefix, rfc6962.AddChainPath), hhOpts)
 		defer server.Close()
 
 		// Increment time to make it unique for each test case.

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -90,76 +90,69 @@ func NewCTStorage(ctx context.Context, opts *CTStorageOptions) (*CTStorage, erro
 	return ctStorage, nil
 }
 
-// dedupFuture returns the index and timestamp matching a future.
+// DedupFuture returns the index and timestamp matching a future.
+//
 // It waits for the entry matching the future to be integrated, fetches it and
 // extracts the timstamp from it.
 //
-// dedupFuture returns tessera.ErrPushback if too many concurent calls are in flight.
+// DedupFuture returns tessera.ErrPushback if too many concurent calls are in flight.
 // Use resetDedupsInFlightJob to periodically reset the number of calls in flight.
 //
 // TODO(phbnf): cache timestamps (or more) to avoid reparsing the entire leaf bundle
-func (cts *CTStorage) dedupFuture(ctx context.Context, f tessera.IndexFuture) (index, ts uint64, err error) {
+func (cts *CTStorage) DedupFuture(ctx context.Context, f tessera.IndexFuture) (uint64, error) {
 	ctx, span := tracer.Start(ctx, "tesseract.storage.dedupFuture")
 	defer span.End()
 
 	if !cts.dedupFutureLimiter.Allow() {
-		return 0, 0, fmt.Errorf("too many duplicate submissions %w", tessera.ErrPushback)
+		return 0, fmt.Errorf("too many duplicate submissions %w", tessera.ErrPushback)
 	}
 
 	idx, cpRaw, err := cts.awaiter.Await(ctx, f)
 	if err != nil {
-		return 0, 0, fmt.Errorf("error waiting for Tessera index future and its integration: %w", err)
+		return 0, fmt.Errorf("error waiting for Tessera index future and its integration: %w", err)
 	}
 
 	// A https://c2sp.org/static-ct-api logsize is on the second line
 	l := bytes.SplitN(cpRaw, []byte("\n"), 3)
 	if len(l) < 2 {
-		return 0, 0, errors.New("invalid checkpoint - no size")
+		return 0, errors.New("invalid checkpoint - no size")
 	}
 	ckptSize, err := strconv.ParseUint(string(l[1]), 10, 64)
 	if err != nil {
-		return 0, 0, fmt.Errorf("invalid checkpoint - can't extract size: %v", err)
+		return 0, fmt.Errorf("invalid checkpoint - can't extract size: %v", err)
 	}
 
 	eBIdx := idx.Index / layout.EntryBundleWidth
 	eBRaw, err := cts.reader.ReadEntryBundle(ctx, eBIdx, layout.PartialTileSize(0, eBIdx, ckptSize))
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return 0, 0, fmt.Errorf("leaf bundle at index %d not found: %v", eBIdx, err)
+			return 0, fmt.Errorf("leaf bundle at index %d not found: %v", eBIdx, err)
 		}
-		return 0, 0, fmt.Errorf("failed to fetch entry bundle at index %d: %v", eBIdx, err)
+		return 0, fmt.Errorf("failed to fetch entry bundle at index %d: %v", eBIdx, err)
 	}
 	eIdx := idx.Index % layout.EntryBundleWidth
 	t, err := timestamp(eBRaw, eIdx)
 	if err != nil {
-		return 0, 0, fmt.Errorf("failed to extract timestamp of entry %d in bundle index %d: %v", eIdx, eBIdx, err)
+		return 0, fmt.Errorf("failed to extract timestamp of entry %d in bundle index %d: %v", eIdx, eBIdx, err)
 	}
-	return idx.Index, t, nil
+	return t, nil
 }
 
 // Add stores CT entries.
-func (cts *CTStorage) Add(ctx context.Context, entry *ctonly.Entry) (uint64, uint64, error) {
+func (cts *CTStorage) Add(ctx context.Context, entry *ctonly.Entry) (tessera.IndexFuture, error) {
 	ctx, span := tracer.Start(ctx, "tesseract.storage.Add")
 	defer span.End()
 
 	future := cts.storeData(ctx, entry)
-	idx, err := future()
-	if err != nil {
-		return 0, 0, fmt.Errorf("error waiting for Tessera index future: %w", err)
-	}
-
-	if idx.IsDup {
-		return cts.dedupFuture(ctx, future)
-	}
 
 	if cts.enableAwaiter {
-		idx, _, err = cts.awaiter.Await(ctx, future)
+		_, _, err := cts.awaiter.Await(ctx, future)
 		if err != nil {
-			return 0, 0, fmt.Errorf("error waiting for Tessera index future and its integration: %w", err)
+			return future, fmt.Errorf("error waiting for Tessera index future and its integration: %w", err)
 		}
 	}
 
-	return idx.Index, entry.Timestamp, nil
+	return future, nil
 }
 
 // AddIssuerChain stores every chain certificate under its sha256.

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -90,9 +90,6 @@ func NewCTStorage(ctx context.Context, opts *CTStorageOptions) (*CTStorage, erro
 // It waits for the entry matching the future to be integrated, fetches it and
 // extracts the timstamp from it.
 //
-// DedupFuture returns tessera.ErrPushback if too many concurent calls are in flight.
-// Use resetDedupsInFlightJob to periodically reset the number of calls in flight.
-//
 // TODO(phbnf): cache timestamps (or more) to avoid reparsing the entire leaf bundle
 func (cts *CTStorage) DedupFuture(ctx context.Context, f tessera.IndexFuture) (uint64, error) {
 	ctx, span := tracer.Start(ctx, "tesseract.storage.dedupFuture")

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -88,7 +88,7 @@ func NewCTStorage(ctx context.Context, opts *CTStorageOptions) (*CTStorage, erro
 // DedupFuture returns the timestamp matching a future.
 //
 // It waits for the entry matching the future to be integrated, fetches it and
-// extracts the timstamp from it.
+// extracts the timestamp from it.
 //
 // TODO(phbnf): cache timestamps (or more) to avoid reparsing the entire leaf bundle
 func (cts *CTStorage) DedupFuture(ctx context.Context, f tessera.IndexFuture) (uint64, error) {


### PR DESCRIPTION
This PR changes how dedup operations are rate limited. Overall, it:
 - moves dedupInFlight to a proper rater limiter
 - moves the rate limiting from storage.go to handlers.go
 - changes the flag name controlling this behaviour to `rate_limit_dedup`
 - adds tests
 - wires everything up with Terraform