### PR TITLE
Make path of ci log configurable for cloudbuild

### DIFF
--- a/deployment/live/gcp/static-ct/cloudbuild/root.hcl
+++ b/deployment/live/gcp/static-ct/cloudbuild/root.hcl
@@ -3,12 +3,15 @@ terraform {
 }
 
 locals {
-  env          = path_relative_to_include()
-  project_id   = get_env("GOOGLE_PROJECT", "static-ct")
-  location     = get_env("GOOGLE_REGION", "us-central1")
-  base_name    = get_env("TESSERA_BASE_NAME", "${local.env}-cloudbuild")
-  github_owner = get_env("GITHUB_OWNER", "transparency-dev")
+  env            = path_relative_to_include()
+  project_id     = get_env("GOOGLE_PROJECT", "static-ct")
+  location       = get_env("GOOGLE_REGION", "us-central1")
+  base_name      = get_env("TESSERA_BASE_NAME", "${local.env}-cloudbuild")
+  github_owner   = get_env("GITHUB_OWNER", "transparency-dev")
+  log_terragrunt = "deployment/live/gcp/static-ct/logs/ci"
 }
+
+inputs = local
 
 remote_state {
   backend = "gcs"

--- a/deployment/modules/gcp/cloudbuild/conformance/main.tf
+++ b/deployment/modules/gcp/cloudbuild/conformance/main.tf
@@ -72,7 +72,7 @@ resource "google_cloudbuild_trigger" "build_trigger" {
       ]
     }
 
-    ## Destroy any pre-existing deployment/live/gcp/static-ct/logs/ci environment.
+    ## Destroy any pre-existing infrastructure.
     ## This might happen if a previous cloud build failed for some reason.
     step {
       id     = "preclean_env"
@@ -80,7 +80,7 @@ resource "google_cloudbuild_trigger" "build_trigger" {
       script = <<EOT
         terragrunt --terragrunt-non-interactive --terragrunt-no-color destroy -auto-approve -no-color 2>&1
       EOT
-      dir    = "deployment/live/gcp/static-ct/logs/ci"
+      dir    = var.log_terragrunt
       env = [
         "GOOGLE_PROJECT=${var.project_id}",
         "TF_IN_AUTOMATION=1",

--- a/deployment/modules/gcp/cloudbuild/conformance/variables.tf
+++ b/deployment/modules/gcp/cloudbuild/conformance/variables.tf
@@ -22,3 +22,8 @@ variable "github_owner" {
   description = "GitHub owner used in Cloud Build trigger repository mapping"
   type        = string
 }
+
+variable "log_terragrunt" {
+  description = "Path of the log terragrunt configs to deploy, from the root of the repository"
+  type        = string
+}


### PR DESCRIPTION
This makes the cloudbuild conformance module usable with a different GCP project.