### PR TITLE
Migrate to cloud-init

### DIFF
--- a/deployment/modules/gcp/gce/preloader/main.tf
+++ b/deployment/modules/gcp/gce/preloader/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "6.43.0"
+      version = "6.50.0"
     }
   }
 }

--- a/deployment/modules/gcp/gce/tesseract/main.tf
+++ b/deployment/modules/gcp/gce/tesseract/main.tf
@@ -45,6 +45,11 @@ locals {
 
   container_name = "tesseract-${var.base_name}"
 
+  // cloud_init is the config used to configure the COS VM.
+  //
+  // See:
+  // - Cloud Init docs: https://cloudinit.readthedocs.io/en/latest/index.html
+  // - Systemd config docs: https://www.freedesktop.org/software/systemd/man/latest/systemd.directives.html
   cloud_init = <<EOT
     #cloud-config
 
@@ -76,6 +81,7 @@ locals {
 
           [Service]
           ExecStartPre=sudo -u tesseract /usr/bin/docker-credential-gcr configure-docker --registries ${var.location}-docker.pkg.dev
+          # --log-driver=gcplogs below causes Docker to integrate with GCP logging such that we can inspect TesseraCT's logs in the GCP Log Explorer.
           ExecStart=sudo -u tesseract -E /usr/bin/docker run --rm -u 2000 --name=${local.container_name} -p 80:80 --log-driver=gcplogs ${var.server_docker_image} ${local.tesseract_args}
           ExecStop=sudo -u tesseract /usr/bin/docker stop ${local.container_name}
           ExecStopPost=sudo -u /usr/bin/docker rm ${local.container_name}

--- a/deployment/modules/gcp/gce/tesseract/main.tf
+++ b/deployment/modules/gcp/gce/tesseract/main.tf
@@ -14,41 +14,12 @@ locals {
   spanner_antispam_db_path    = "projects/${var.project_id}/instances/${var.log_spanner_instance}/databases/${var.antispam_spanner_db}"
 }
 
-module "gce_container_tesseract" {
-  # https://github.com/terraform-google-modules/terraform-google-container-vm
-  source  = "terraform-google-modules/container-vm/google"
-  version = "~> 2.0"
-
-  container = {
-    image = var.server_docker_image
-    args = [
-      "--logtostderr",
-      "--v=3",
-      "--http_endpoint=:80",
-      "--bucket=${var.bucket}",
-      "--spanner_db_path=${local.spanner_log_db_path}",
-      "--spanner_antispam_db_path=${local.spanner_antispam_db_path}",
-      "--roots_pem_file=/bin/test_root_ca_cert.pem",
-      "--origin=${var.base_name}${var.origin_suffix}",
-      "--signer_public_key_secret_name=${var.signer_public_key_secret_name}",
-      "--signer_private_key_secret_name=${var.signer_private_key_secret_name}",
-      "--inmemory_antispam_cache_size=256k",
-      "--not_after_start=${var.not_after_start}",
-      "--not_after_limit=${var.not_after_limit}",
-      "--trace_fraction=${var.trace_fraction}",
-      "--batch_max_size=${var.batch_max_size}",
-      "--batch_max_age=${var.batch_max_age}",
-      "--enable_publication_awaiter=${var.enable_publication_awaiter}",
-      "--accept_sha1_signing_algorithms=true",
-      "--rate_limit_old_not_before=${var.rate_limit_old_not_before}",
-      "--rate_limit_dedup=${var.rate_limit_dedup}"
-    ]
-    tty : true # maybe remove this
-  }
-
-  restart_policy = "Always"
+data "google_compute_image" "cos" {
+  family  = "cos-121-lts"
+  project = "cos-cloud"
 }
 
+         
 resource "google_compute_region_instance_template" "tesseract" {
   // Templates cannot be updated, so we generate a new one every time.
   name_prefix = "tesseract-template-"
@@ -63,7 +34,6 @@ resource "google_compute_region_instance_template" "tesseract" {
 
   labels = {
     environment  = var.env
-    container-vm = module.gce_container_tesseract.vm_container_label
   }
 
   instance_description = "TesseraCT"
@@ -76,7 +46,7 @@ resource "google_compute_region_instance_template" "tesseract" {
 
   // Create a new boot disk from an image
   disk {
-    source_image = module.gce_container_tesseract.source_image
+    source_image = data.google_compute_image.cos.self_link
     auto_delete  = true
     boot         = true
   }
@@ -86,10 +56,54 @@ resource "google_compute_region_instance_template" "tesseract" {
   }
 
   metadata = {
-    gce-container-declaration = module.gce_container_tesseract.metadata_value
     google-logging-enabled    = "true"
     google-monitoring-enabled = "true"
   }
+
+  metadata_startup_script = <<EOT
+    # /root is read-only on COS, but we need a writable HOME for docker-credential-gcr to store
+    # creds for docker, so make one and set the HOME env var.
+    export HOME=/home/tesseract
+    mkdir -p $HOME
+    cd $HOME
+    docker-credential-gcr configure-docker --include-artifact-registry -registries=${var.location}
+
+    # A name for the container
+    CONTAINER_NAME="tesseract"
+    # The image it'll run
+    IMAGE="${var.server_docker_image}"
+    
+    # Stop and remove the container if it exists
+    docker stop $CONTAINER_NAME || true
+    docker rm $CONTAINER_NAME || true
+    
+    # Run docker container from image in docker hub
+    docker run \
+      --name="$CONTAINER_NAME" \
+      --restart=always \
+      --privileged \
+      $IMAGE \
+          --logtostderr \
+          --v=3 \
+          --http_endpoint=:80 \
+          --bucket=${var.bucket} \
+          --spanner_db_path=${local.spanner_log_db_path} \
+          --spanner_antispam_db_path=${local.spanner_antispam_db_path} \
+          --roots_pem_file=/bin/test_root_ca_cert.pem \
+          --origin=${var.base_name}${var.origin_suffix} \
+          --signer_public_key_secret_name=${var.signer_public_key_secret_name} \
+          --signer_private_key_secret_name=${var.signer_private_key_secret_name} \
+          --inmemory_antispam_cache_size=256k \
+          --not_after_start=${var.not_after_start} \
+          --not_after_limit=${var.not_after_limit} \
+          --trace_fraction=${var.trace_fraction} \
+          --batch_max_size=${var.batch_max_size} \
+          --batch_max_age=${var.batch_max_age} \
+          --enable_publication_awaiter=${var.enable_publication_awaiter} \
+          --accept_sha1_signing_algorithms=true \
+          --rate_limit_old_not_before=${var.rate_limit_old_not_before} \
+          --rate_limit_dedup=${var.rate_limit_dedup}
+      EOT
 
   service_account {
     # Google recommends custom service accounts that have cloud-platform scope and permissions granted via IAM Roles.
@@ -122,6 +136,15 @@ resource "google_compute_region_instance_group_manager" "instance_group_manager"
 
   version {
     instance_template = google_compute_region_instance_template.tesseract.id
+  }
+
+  all_instances_config {
+    metadata = {
+      service_name = var.base_name 
+    }
+    labels = {
+      service_name =var.base_name 
+    }
   }
 
   base_instance_name = var.base_name

--- a/deployment/modules/gcp/gce/tesseract/main.tf
+++ b/deployment/modules/gcp/gce/tesseract/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "6.43.0"
+      version = "6.50.0"
     }
   }
 }
@@ -15,14 +15,14 @@ locals {
 }
 
 data "google_compute_image" "cos" {
-  family  = "cos-beta"
+  family  = "cos-121-lts"
   project = "cos-cloud"
 }
 
 locals {
   tesseract_args = join(" ", [
          "-logtostderr",
-         "-v=3",
+         "-v=2",
          "-http_endpoint=:80",
          "-bucket=${var.bucket}",
          "-spanner_db_path=${local.spanner_log_db_path}",
@@ -161,13 +161,15 @@ resource "google_compute_region_instance_group_manager" "instance_group_manager"
   version {
     instance_template = google_compute_region_instance_template.tesseract.id
   }
+  wait_for_instances = true
+  wait_for_instances_status = "UPDATED"
 
   all_instances_config {
     metadata = {
       service_name = var.base_name 
     }
     labels = {
-      service_name =var.base_name 
+      service_name = var.base_name 
     }
   }
 

--- a/deployment/modules/gcp/gce/tesseract/variables.tf
+++ b/deployment/modules/gcp/gce/tesseract/variables.tf
@@ -109,5 +109,5 @@ variable "rate_limit_old_not_before" {
 variable "rate_limit_dedup" {
   description = "Set to rate limit duplicate submissions per second."
   type        = number
-  default     = -1 
+  default     = -1
 }

--- a/deployment/modules/gcp/loadbalancer/external/main.tf
+++ b/deployment/modules/gcp/loadbalancer/external/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "6.43.0"
+      version = "6.50.0"
     }
   }
 

--- a/deployment/modules/gcp/loadbalancer/internal/main.tf
+++ b/deployment/modules/gcp/loadbalancer/internal/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "6.43.0"
+      version = "6.50.0"
     }
   }
 }

--- a/deployment/modules/gcp/secretmanager/main.tf
+++ b/deployment/modules/gcp/secretmanager/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "6.43.0"
+      version = "6.50.0"
     }
   }
 }

--- a/deployment/modules/gcp/storage/main.tf
+++ b/deployment/modules/gcp/storage/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "6.43.0"
+      version = "6.50.0"
     }
   }
 }


### PR DESCRIPTION
This PR migrates away from the to-be-deprecated GCE-just-run-a-VM option to use `cloud-init` instead.

The VM is configured such that:
- a new systemd service which uses Docker to run the tesseract binary is created
- the Docker container is named using the origin prefix for ease of grouping logging in GCP (using `jsonPayload.container.name=...` as a filter)

and the MIG terraform resource is now configured to cause the `terraform` command to wait for the managed instances to be successfully updated before returning, this means that it's no longer possible for a bad update to silently roll back.