### PR TITLE
Add support for additional ed25519 signers to terraform

### DIFF
--- a/deployment/live/gcp/static-ct-staging/logs/README.md
+++ b/deployment/live/gcp/static-ct-staging/logs/README.md
@@ -127,6 +127,7 @@ These keys MUST be stored as note-formatted signing keys (see https://pkg.go.dev
 Since such keys are not natively supported by either Terraform/OpenTofu or Secret Manager, they must be created manually.
 This is easily achieved by running the command below in Cloud Shell, note that `${LOG_ORIGIN}` MUST be set to the full `origin` line of the
 log which will use this key, and `${TESSERA_BASE_NAME}` SHOULD be set to whatever `locals.base_name` is in the log terragrunt config:
+
 ```bash
 go run github.com/transparency-dev/serverless-log/cmd/generate_keys@HEAD \
    --key_name="${LOG_ORIGIN}" \

--- a/deployment/live/gcp/static-ct-staging/logs/arche2025h1/terragrunt.hcl
+++ b/deployment/live/gcp/static-ct-staging/logs/arche2025h1/terragrunt.hcl
@@ -3,18 +3,18 @@ terraform {
 }
 
 locals {
-  env                           = include.root.locals.env
-  docker_env                    = local.env
-  base_name                     = include.root.locals.base_name
-  origin_suffix                 = include.root.locals.origin_suffix
-  not_after_start               = "2025-01-01T00:00:00Z"
-  not_after_limit               = "2025-07-01T00:00:00Z"
-  server_docker_image           = "${include.root.locals.location}-docker.pkg.dev/${include.root.locals.project_id}/docker-${local.env}/tesseract-gcp:${include.root.locals.docker_container_tag}"
-  spanner_pu                    = 500
-  trace_fraction                = 0.1
-  create_internal_load_balancer = true
-  public_bucket                 = true
-  rate_limit_old_not_before     = "28h:150"
+  env                                        = include.root.locals.env
+  docker_env                                 = local.env
+  base_name                                  = include.root.locals.base_name
+  origin_suffix                              = include.root.locals.origin_suffix
+  not_after_start                            = "2025-01-01T00:00:00Z"
+  not_after_limit                            = "2025-07-01T00:00:00Z"
+  server_docker_image                        = "${include.root.locals.location}-docker.pkg.dev/${include.root.locals.project_id}/docker-${local.env}/tesseract-gcp:${include.root.locals.docker_container_tag}"
+  spanner_pu                                 = 500
+  trace_fraction                             = 0.1
+  create_internal_load_balancer              = true
+  public_bucket                              = true
+  rate_limit_old_not_before                  = "28h:150"
   additional_signer_private_key_secret_names = ["projects/781477119959/secrets/arche2025h1-ed25519-private-key/versions/1"]
 }
 

--- a/deployment/live/gcp/static-ct-staging/logs/arche2025h1/terragrunt.hcl
+++ b/deployment/live/gcp/static-ct-staging/logs/arche2025h1/terragrunt.hcl
@@ -15,6 +15,7 @@ locals {
   create_internal_load_balancer = true
   public_bucket                 = true
   rate_limit_old_not_before     = "28h:150"
+  additional_signer_private_key_secret_names = ["projects/781477119959/secrets/arche2025h1-ed25519-private-key/versions/1"]
 }
 
 include "root" {

--- a/deployment/live/gcp/static-ct-staging/logs/arche2025h2/terragrunt.hcl
+++ b/deployment/live/gcp/static-ct-staging/logs/arche2025h2/terragrunt.hcl
@@ -16,6 +16,7 @@ locals {
   public_bucket                 = true
   machine_type                  = "n2-standard-8"
   rate_limit_old_not_before     = "28h:150"
+  additional_signer_private_key_secret_names = ["projects/781477119959/secrets/arche2025h2-ed25519-private-key/versions/1"]
 }
 
 include "root" {

--- a/deployment/live/gcp/static-ct-staging/logs/arche2025h2/terragrunt.hcl
+++ b/deployment/live/gcp/static-ct-staging/logs/arche2025h2/terragrunt.hcl
@@ -3,19 +3,19 @@ terraform {
 }
 
 locals {
-  env                           = include.root.locals.env
-  docker_env                    = local.env
-  base_name                     = include.root.locals.base_name
-  origin_suffix                 = include.root.locals.origin_suffix
-  not_after_start               = "2025-07-01T00:00:00Z"
-  not_after_limit               = "2026-01-01T00:00:00Z"
-  server_docker_image           = "${include.root.locals.location}-docker.pkg.dev/${include.root.locals.project_id}/docker-${local.env}/tesseract-gcp:${include.root.locals.docker_container_tag}"
-  spanner_pu                    = 500
-  trace_fraction                = 0.1
-  create_internal_load_balancer = true
-  public_bucket                 = true
-  machine_type                  = "n2-standard-8"
-  rate_limit_old_not_before     = "28h:150"
+  env                                        = include.root.locals.env
+  docker_env                                 = local.env
+  base_name                                  = include.root.locals.base_name
+  origin_suffix                              = include.root.locals.origin_suffix
+  not_after_start                            = "2025-07-01T00:00:00Z"
+  not_after_limit                            = "2026-01-01T00:00:00Z"
+  server_docker_image                        = "${include.root.locals.location}-docker.pkg.dev/${include.root.locals.project_id}/docker-${local.env}/tesseract-gcp:${include.root.locals.docker_container_tag}"
+  spanner_pu                                 = 500
+  trace_fraction                             = 0.1
+  create_internal_load_balancer              = true
+  public_bucket                              = true
+  machine_type                               = "n2-standard-8"
+  rate_limit_old_not_before                  = "28h:150"
   additional_signer_private_key_secret_names = ["projects/781477119959/secrets/arche2025h2-ed25519-private-key/versions/1"]
 }
 

--- a/deployment/live/gcp/static-ct-staging/logs/arche2026h1/terragrunt.hcl
+++ b/deployment/live/gcp/static-ct-staging/logs/arche2026h1/terragrunt.hcl
@@ -15,6 +15,7 @@ locals {
   create_internal_load_balancer = true
   public_bucket                 = true
   rate_limit_old_not_before     = "28h:150"
+  additional_signer_private_key_secret_names = ["projects/781477119959/secrets/arche2026h1-ed25519-private-key/versions/1"]
 }
 
 include "root" {

--- a/deployment/live/gcp/static-ct-staging/logs/arche2026h1/terragrunt.hcl
+++ b/deployment/live/gcp/static-ct-staging/logs/arche2026h1/terragrunt.hcl
@@ -3,18 +3,18 @@ terraform {
 }
 
 locals {
-  env                           = include.root.locals.env
-  docker_env                    = local.env
-  base_name                     = include.root.locals.base_name
-  origin_suffix                 = include.root.locals.origin_suffix
-  not_after_start               = "2026-01-01T00:00:00Z"
-  not_after_limit               = "2026-07-01T00:00:00Z"
-  server_docker_image           = "${include.root.locals.location}-docker.pkg.dev/${include.root.locals.project_id}/docker-${local.env}/tesseract-gcp:${include.root.locals.docker_container_tag}"
-  spanner_pu                    = 500
-  trace_fraction                = 0.1
-  create_internal_load_balancer = true
-  public_bucket                 = true
-  rate_limit_old_not_before     = "28h:150"
+  env                                        = include.root.locals.env
+  docker_env                                 = local.env
+  base_name                                  = include.root.locals.base_name
+  origin_suffix                              = include.root.locals.origin_suffix
+  not_after_start                            = "2026-01-01T00:00:00Z"
+  not_after_limit                            = "2026-07-01T00:00:00Z"
+  server_docker_image                        = "${include.root.locals.location}-docker.pkg.dev/${include.root.locals.project_id}/docker-${local.env}/tesseract-gcp:${include.root.locals.docker_container_tag}"
+  spanner_pu                                 = 500
+  trace_fraction                             = 0.1
+  create_internal_load_balancer              = true
+  public_bucket                              = true
+  rate_limit_old_not_before                  = "28h:150"
   additional_signer_private_key_secret_names = ["projects/781477119959/secrets/arche2026h1-ed25519-private-key/versions/1"]
 }
 

--- a/deployment/modules/aws/secretsmanager/main.tf
+++ b/deployment/modules/aws/secretsmanager/main.tf
@@ -14,7 +14,7 @@ provider "aws" {
 
 # Secrets Manager
 resource "aws_secretsmanager_secret" "tesseract_ecdsa_p256_public_key" {
-  name = "${var.base_name}-ecdsa-p256-public-key"
+  name                    = "${var.base_name}-ecdsa-p256-public-key"
   recovery_window_in_days = 0
 
   tags = {
@@ -28,9 +28,9 @@ resource "aws_secretsmanager_secret_version" "tesseract_ecdsa_p256_public_key" {
 }
 
 resource "aws_secretsmanager_secret" "tesseract_ecdsa_p256_private_key" {
-  name = "${var.base_name}-ecdsa-p256-private-key"
+  name                    = "${var.base_name}-ecdsa-p256-private-key"
   recovery_window_in_days = 0
-  
+
   tags = {
     label = "tesseract-private-key"
   }

--- a/deployment/modules/gcp/cloudbuild/tesseract/variables.tf
+++ b/deployment/modules/gcp/cloudbuild/tesseract/variables.tf
@@ -25,5 +25,5 @@ variable "github_owner" {
 
 variable "logs_terragrunts" {
   description = "Paths of the log terragrunt configs to deploy, from the root of the repository"
-  type        = list
+  type        = list(any)
 }

--- a/deployment/modules/gcp/gce/preloader/main.tf
+++ b/deployment/modules/gcp/gce/preloader/main.tf
@@ -77,6 +77,6 @@ resource "google_compute_instance" "preloader" {
   service_account {
     # Google recommends custom service accounts that have cloud-platform scope and permissions granted via IAM Roles.
     email  = "${local.preloader_service_account_id}@${var.project_id}.iam.gserviceaccount.com"
-    scopes = ["cloud-platform"]                                                               # Allows using service accounts and OAuth.
+    scopes = ["cloud-platform"] # Allows using service accounts and OAuth.
   }
 }

--- a/deployment/modules/gcp/gce/tesseract/main.tf
+++ b/deployment/modules/gcp/gce/tesseract/main.tf
@@ -10,8 +10,8 @@ terraform {
 locals {
   # TODO(phbnf): use a different service account
   tesseract_service_account_id = var.env == "" ? "tesseract-sa" : "tesseract-${var.env}-sa"
-  spanner_log_db_path         = "projects/${var.project_id}/instances/${var.log_spanner_instance}/databases/${var.log_spanner_db}"
-  spanner_antispam_db_path    = "projects/${var.project_id}/instances/${var.log_spanner_instance}/databases/${var.antispam_spanner_db}"
+  spanner_log_db_path          = "projects/${var.project_id}/instances/${var.log_spanner_instance}/databases/${var.log_spanner_db}"
+  spanner_antispam_db_path     = "projects/${var.project_id}/instances/${var.log_spanner_instance}/databases/${var.antispam_spanner_db}"
 }
 
 data "google_compute_image" "cos" {
@@ -21,7 +21,7 @@ data "google_compute_image" "cos" {
 
 locals {
 
-  witness_policy_file="/etc/tesseract-witness.policy"
+  witness_policy_file = "/etc/tesseract-witness.policy"
 
   # docker_run_args are provided to the docker run command.
   # Use this to configure docker-specific things.
@@ -36,28 +36,28 @@ locals {
 
   # tesseract_args are provided to the tesseract command.
   tesseract_args = join(" ", [
-         "-logtostderr",
-         "-v=2",
-         "-http_endpoint=:80",
-         "-bucket=${var.bucket}",
-         "-spanner_db_path=${local.spanner_log_db_path}",
-         "-spanner_antispam_db_path=${local.spanner_antispam_db_path}",
-         "-roots_pem_file=/bin/test_root_ca_cert.pem",
-         "-origin=${var.base_name}${var.origin_suffix}",
-         "-signer_public_key_secret_name=${var.signer_public_key_secret_name}",
-         "-signer_private_key_secret_name=${var.signer_private_key_secret_name}",
-         "-inmemory_antispam_cache_size=256k",
-         "-not_after_start=${var.not_after_start}",
-         "-not_after_limit=${var.not_after_limit}",
-         "-trace_fraction=${var.trace_fraction}",
-         "-batch_max_size=${var.batch_max_size}",
-         "-batch_max_age=${var.batch_max_age}",
-         "-enable_publication_awaiter=${var.enable_publication_awaiter}",
-         "-accept_sha1_signing_algorithms=true",
-         "-rate_limit_old_not_before=${var.rate_limit_old_not_before}",
-         "-rate_limit_dedup=${var.rate_limit_dedup}",
-        var.witness_policy == "" ? "" : "-witness_policy_file=${local.witness_policy_file}",
-        length(var.additional_signer_private_key_secret_names) == 0 ? "" : join(" ", formatlist("-additional_signer_private_key_secret_name=%s", var.additional_signer_private_key_secret_names))
+    "-logtostderr",
+    "-v=2",
+    "-http_endpoint=:80",
+    "-bucket=${var.bucket}",
+    "-spanner_db_path=${local.spanner_log_db_path}",
+    "-spanner_antispam_db_path=${local.spanner_antispam_db_path}",
+    "-roots_pem_file=/bin/test_root_ca_cert.pem",
+    "-origin=${var.base_name}${var.origin_suffix}",
+    "-signer_public_key_secret_name=${var.signer_public_key_secret_name}",
+    "-signer_private_key_secret_name=${var.signer_private_key_secret_name}",
+    "-inmemory_antispam_cache_size=256k",
+    "-not_after_start=${var.not_after_start}",
+    "-not_after_limit=${var.not_after_limit}",
+    "-trace_fraction=${var.trace_fraction}",
+    "-batch_max_size=${var.batch_max_size}",
+    "-batch_max_age=${var.batch_max_age}",
+    "-enable_publication_awaiter=${var.enable_publication_awaiter}",
+    "-accept_sha1_signing_algorithms=true",
+    "-rate_limit_old_not_before=${var.rate_limit_old_not_before}",
+    "-rate_limit_dedup=${var.rate_limit_dedup}",
+    var.witness_policy == "" ? "" : "-witness_policy_file=${local.witness_policy_file}",
+    length(var.additional_signer_private_key_secret_names) == 0 ? "" : join(" ", formatlist("-additional_signer_private_key_secret_name=%s", var.additional_signer_private_key_secret_names))
   ])
 
   container_name = "tesseract-${var.base_name}"
@@ -128,7 +128,7 @@ resource "google_compute_region_instance_template" "tesseract" {
   tags = ["tesseract", "allow-health-checks", "preloader"]
 
   labels = {
-    environment  = var.env
+    environment = var.env
   }
 
   instance_description = "TesseraCT"
@@ -156,13 +156,13 @@ resource "google_compute_region_instance_template" "tesseract" {
   metadata = {
     google-logging-enabled    = "true"
     google-monitoring-enabled = "true"
-    user-data = local.cloud_init
+    user-data                 = local.cloud_init
   }
 
   service_account {
     # Google recommends custom service accounts that have cloud-platform scope and permissions granted via IAM Roles.
     email  = "${local.tesseract_service_account_id}@${var.project_id}.iam.gserviceaccount.com"
-    scopes = ["cloud-platform"]                                                               # Allows using service accounts and OAuth.
+    scopes = ["cloud-platform"] # Allows using service accounts and OAuth.
   }
 }
 
@@ -191,15 +191,15 @@ resource "google_compute_region_instance_group_manager" "instance_group_manager"
   version {
     instance_template = google_compute_region_instance_template.tesseract.id
   }
-  wait_for_instances = true
+  wait_for_instances        = true
   wait_for_instances_status = "UPDATED"
 
   all_instances_config {
     metadata = {
-      service_name = var.base_name 
+      service_name = var.base_name
     }
     labels = {
-      service_name = var.base_name 
+      service_name = var.base_name
     }
   }
 

--- a/deployment/modules/gcp/gce/tesseract/main.tf
+++ b/deployment/modules/gcp/gce/tesseract/main.tf
@@ -57,6 +57,7 @@ locals {
          "-rate_limit_old_not_before=${var.rate_limit_old_not_before}",
          "-rate_limit_dedup=${var.rate_limit_dedup}",
         var.witness_policy == "" ? "" : "-witness_policy_file=${local.witness_policy_file}",
+        length(var.additional_signer_private_key_secret_names) == 0 ? "" : join(" ", formatlist("-additional_signer_private_key_secret_name=%s", var.additional_signer_private_key_secret_names))
   ])
 
   container_name = "tesseract-${var.base_name}"

--- a/deployment/modules/gcp/gce/tesseract/variables.tf
+++ b/deployment/modules/gcp/gce/tesseract/variables.tf
@@ -54,6 +54,11 @@ variable "antispam_spanner_db" {
   type        = string
 }
 
+variable "additional_signer_private_key_secret_names" {
+  description = "List of additional private key secret name for checkpoint secondary signers. Format: projects/{projectId}/secrets/{secretName}/versions/{secretVersion}. These secrets MUST be formatted in note signer format."
+  type        = list(string)
+}
+
 variable "signer_public_key_secret_name" {
   description = "Public key secret name for checkpoints and SCTs signer. Format: projects/{projectId}/secrets/{secretName}/versions/{secretVersion}."
   type        = string

--- a/deployment/modules/gcp/storage/variables.tf
+++ b/deployment/modules/gcp/storage/variables.tf
@@ -15,17 +15,17 @@ variable "location" {
 
 variable "ephemeral" {
   description = "Set to true if this is a throwaway/temporary log instance. Will set attributes on created resources to allow them to be disabled/deleted more easily."
-  type = bool
+  type        = bool
 }
 
 variable "spanner_pu" {
   description = "Amount of Spanner processing units"
-  type = number
-  default = 100
+  type        = number
+  default     = 100
 }
 
 variable "public_bucket" {
   description = "Set to true to make the log's GCS bucket publicly accessible"
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }

--- a/deployment/modules/gcp/tesseract/cloudrun/variables.tf
+++ b/deployment/modules/gcp/tesseract/cloudrun/variables.tf
@@ -47,8 +47,8 @@ variable "server_docker_image" {
 
 variable "spanner_pu" {
   description = "Amount of Spanner processing units"
-  type = number
-  default = 100
+  type        = number
+  default     = 100
 }
 
 variable "batch_max_size" {

--- a/deployment/modules/gcp/tesseract/gce/main.tf
+++ b/deployment/modules/gcp/tesseract/gce/main.tf
@@ -37,6 +37,7 @@ module "gce" {
   antispam_spanner_db            = module.storage.antispam_spanner_db.name
   signer_public_key_secret_name  = module.secretmanager.ecdsa_p256_public_key_id
   signer_private_key_secret_name = module.secretmanager.ecdsa_p256_private_key_id
+  additional_signer_private_key_secret_names = var.additional_signer_private_key_secret_names
   trace_fraction                 = var.trace_fraction
   batch_max_age                  = var.batch_max_age
   batch_max_size                 = var.batch_max_size

--- a/deployment/modules/gcp/tesseract/gce/main.tf
+++ b/deployment/modules/gcp/tesseract/gce/main.tf
@@ -22,29 +22,29 @@ module "secretmanager" {
 module "gce" {
   source = "../../gce/tesseract"
 
-  env                            = var.env
-  project_id                     = var.project_id
-  base_name                      = var.base_name
-  origin_suffix                  = var.origin_suffix
-  location                       = var.location
-  server_docker_image            = var.server_docker_image
-  machine_type                   = var.machine_type
-  not_after_start                = var.not_after_start
-  not_after_limit                = var.not_after_limit
-  bucket                         = module.storage.log_bucket.id
-  log_spanner_instance           = module.storage.log_spanner_instance.name
-  log_spanner_db                 = module.storage.log_spanner_db.name
-  antispam_spanner_db            = module.storage.antispam_spanner_db.name
-  signer_public_key_secret_name  = module.secretmanager.ecdsa_p256_public_key_id
-  signer_private_key_secret_name = module.secretmanager.ecdsa_p256_private_key_id
+  env                                        = var.env
+  project_id                                 = var.project_id
+  base_name                                  = var.base_name
+  origin_suffix                              = var.origin_suffix
+  location                                   = var.location
+  server_docker_image                        = var.server_docker_image
+  machine_type                               = var.machine_type
+  not_after_start                            = var.not_after_start
+  not_after_limit                            = var.not_after_limit
+  bucket                                     = module.storage.log_bucket.id
+  log_spanner_instance                       = module.storage.log_spanner_instance.name
+  log_spanner_db                             = module.storage.log_spanner_db.name
+  antispam_spanner_db                        = module.storage.antispam_spanner_db.name
+  signer_public_key_secret_name              = module.secretmanager.ecdsa_p256_public_key_id
+  signer_private_key_secret_name             = module.secretmanager.ecdsa_p256_private_key_id
   additional_signer_private_key_secret_names = var.additional_signer_private_key_secret_names
-  trace_fraction                 = var.trace_fraction
-  batch_max_age                  = var.batch_max_age
-  batch_max_size                 = var.batch_max_size
-  enable_publication_awaiter     = var.enable_publication_awaiter
-  rate_limit_old_not_before      = var.rate_limit_old_not_before
-  rate_limit_dedup               = var.rate_limit_dedup
-  witness_policy                 = var.witness_policy
+  trace_fraction                             = var.trace_fraction
+  batch_max_age                              = var.batch_max_age
+  batch_max_size                             = var.batch_max_size
+  enable_publication_awaiter                 = var.enable_publication_awaiter
+  rate_limit_old_not_before                  = var.rate_limit_old_not_before
+  rate_limit_dedup                           = var.rate_limit_dedup
+  witness_policy                             = var.witness_policy
 
   depends_on = [
     module.secretmanager,

--- a/deployment/modules/gcp/tesseract/gce/variables.tf
+++ b/deployment/modules/gcp/tesseract/gce/variables.tf
@@ -111,10 +111,13 @@ variable "rate_limit_dedup" {
   default     = -1 
 }
 
-
 variable "witness_policy" {
   description = "Set to apply a witness policy which will be used by TesseraCT to gather cosignatures for checkpoints."
   type        = string
   default     = ""
 }
 
+variable "additional_signer_private_key_secret_names" {
+  description = "List of additional private key secret name for checkpoint secondary signers. Format: projects/{projectId}/secrets/{secretName}/versions/{secretVersion}. These secrets MUST be formatted as serialised note signers."
+  type        = list(string)
+}

--- a/deployment/modules/gcp/tesseract/gce/variables.tf
+++ b/deployment/modules/gcp/tesseract/gce/variables.tf
@@ -108,7 +108,7 @@ variable "rate_limit_old_not_before" {
 variable "rate_limit_dedup" {
   description = "Set to rate limit duplicate submissions per second."
   type        = number
-  default     = -1 
+  default     = -1
 }
 
 variable "witness_policy" {


### PR DESCRIPTION
This PR adds support for configuring additional Ed25519 signers to terraform.

These signers will be used by TesseraCT to provide additional checkpoint signatures which enable the checkpoint to be accepted by witnesses.